### PR TITLE
Sensitivity multi pft

### DIFF
--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -262,7 +262,7 @@ class SensitivityDriver(object):
 
     self.set_work_dir(work_dir)
 
-    self.site = '/data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_CALM_Toolik_LTER_10x10/'
+    self.site = '/work/demo-data/cru-ts40_ar5_rcp85_ncar-ccsm4_toolik_field_station_10x10'
     self.PXx = 0
     self.PXy = 0
     self.outputs = [

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -813,15 +813,19 @@ class SensitivityDriver(object):
         for f in sorted(results, key=sort_stage):
           stg_data = nc.Dataset(f, 'r')
           d = stg_data.variables[o['name']][:]
-          # if o['type'] == 'pool':
-          #   d = ou.average_monthly_pool_to_yearly(d)
-          # elif o['type'] == 'flux':
-          #   d = ou.sum_monthly_flux_to_yearly(d)
-          d = pd.DataFrame(d[:,self.pftnum(),self.PXy,self.PXx], columns=[o['name']])
+          if o['type'] == 'pool':
+            d = ou.average_monthly_pool_to_yearly(d)
+          elif o['type'] == 'flux':
+            d = ou.sum_monthly_flux_to_yearly(d)
+          else:
+            print("What the heck??")
+          d = ou.sum_across_pfts(d)
+          d = pd.DataFrame(d[:,self.PXy,self.PXx], columns=[o['name']])
           all_data = all_data.append(d, ignore_index=True)
 
         axes[i].plot(all_data)
         axes[i].set_ylabel(o['name'])
+    plt.show()
 
   def extract_data_for_sensitivity_analysis(self, posthoc=True, multi=True):
     '''

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -204,53 +204,60 @@ class SensitivityDriver(object):
   '''
   Sensitivity Analysis Driver class.
 
-  Driver class for conducting ``dvmdostem`` SensitivityAnalysis.
-  Methods for cleaning, setup, running model, collecting outputs.
+  Driver class for conducting ``dvmdostem`` SensitivityAnalysis. Methods for
+  cleaning, setup, running model, collecting outputs.
 
   Basic overview of use is like this:
 
     1. Instantiate driver object.
-    2. Setup/design the experiment (working directory, seed path, parameters to 
+    2. Setup/design the experiment (working directory, seed path, parameters to
        use, number of samples, etc)
     3. Use driver object to setup the run folders.
     4. Use driver object to carry out model runs.
     5. Use driver object to summarize/collect outputs.
     6. Use driver object to make plots, do analysis.
 
-
   Parameters
   ----------
   work_dir : str, optional
     The working directory path of the driver object.
 
-  sampling_method : str one of {None, 'lhc','uniform'}, optional
-    The method by which the sample should be chosen. 
+  sampling_method : { None, 'lhc', 'uniform' }
+    Method that should be used to draw samples from the specified ranges in
+    order to construct the sample matrix. `lhc` will use the Latin Hyper Cube
+    sampling method and `uniform` will draw from a uniform distribution. The
+    default `None` is simply a placeholder.
 
-  clean : bool, optional
-    CAREFUL! - this will forecfully remove the entrire tree rooted at `work_dir`.
-
-
-  See Also
-  --------
+  clean : bool, default=False
+    CAREFUL! - this will forecfully remove the entrire tree rooted at
+    `work_dir`.
 
   Examples
   --------
+  Instantiate object, sets pixel, outputs, working directory, site selection
+  (input data path)
 
-  >>> driver = SensitivityDriver('/tmp/Sensitivity-inline-test')
-  >>> driver.set_seed_path('/work/parameters')
+      >>> driver = SensitivityDriver()
 
+  Set the working directory for the driver (using something temporary for this
+  test case).
+
+      >>> driver.work_dir = '/tmp/Sensitivity-inline-test'
+
+  Show info about the driver object:
+
+      >>> driver.design_experiment(5, 4, params=['cmax','rhq10','nfall(1)'], pftnums=[2,None,2])
+      >>> driver.sample_matrix
+              cmax     rhq10  nfall(1)
+      0  63.536594  1.919504  0.000162
+      1  62.528847  2.161819  0.000159
+      2  67.606747  1.834203  0.000145
+      3  59.671967  2.042034  0.000171
+      4  57.711999  1.968631  0.000155
   '''
   def __init__(self, work_dir=None, sampling_method=None, clean=False):
-    '''
-    Constructor.
+    '''Create a SensitivityDriver object.'''
 
-    Hard code a bunch of stuff for now...
-
-    Returns
-    -------
-    SensitivityDriver
-      A constructed driver object.
-    '''
     self.__seedpath = None
 
     self.set_work_dir(work_dir)
@@ -543,8 +550,7 @@ class SensitivityDriver(object):
     ----------
     row : dict
       One row of the sample matrix, in dict form. So like this:
-        `{'cmax': 108.2, 'rhq10': 34.24}`
-      with one key for each parameter name.
+      `{'cmax': 108.2, 'rhq10': 34.24}` with one key for each parameter name.
 
     idx : int
       The row index of the `sample_matrix` being worked on. Gets
@@ -789,13 +795,16 @@ class SensitivityDriver(object):
     the data will look like this, with one row for each sample, 
     and one column for each parameter followed by one column for
     each output:
-    p_cmax,  p_rhq10,   p_micbnup,   o_GPP,  o_VEGC
-    1.215,   2.108,     0.432,       0.533,  5.112
-    1.315,   3.208,     0.632,       0.721,  8.325
-    1.295,   1.949,     0.468,       0.560,  5.201
-    1.189,   2.076,     0.420,       0.592,  5.310
-    1.138,   2.035,     0.441,       0.537,  5.132
-    1.156,   1.911,     0.433,       0.557,  5.192
+
+    :: 
+
+      p_cmax,  p_rhq10,   p_micbnup,   o_GPP,  o_VEGC
+      1.215,   2.108,     0.432,       0.533,  5.112
+      1.315,   3.208,     0.632,       0.721,  8.325
+      1.295,   1.949,     0.468,       0.560,  5.201
+      1.189,   2.076,     0.420,       0.592,  5.310
+      1.138,   2.035,     0.441,       0.537,  5.132
+      1.156,   1.911,     0.433,       0.557,  5.192
     
     Return
     ------
@@ -864,40 +873,36 @@ class SensitivityDriver(object):
 
   def extract_data_for_sensitivity_analysis(self, posthoc=True, multi=True):
     '''
-    Creates a csv file in each run directory that summarizes
-    the run's parameters and outut. The csv file will look 
-    something like this:
+    Creates a csv file in each run directory that summarizes the run's
+    parameters and outut. The csv file will look something like this:
 
-    p_cmax,  p_rhq10,   p_micbnup,   o_GPP,  o_VEGC
-    1.215,   2.108,     0.432,       0.533,  5.112
+    ::
 
-    with one columns for each parameter and one column for 
-    each output. The
-
-    For each row in the sensitivity matrix (and corresponding 
-    run folder), 
-      For each variable specified in self.outputs:
-          - opens the NetCDF files that were output from
-            dvmdostem
-          - grabs the last datapoint
-          - writes it to the sensitivity.csv file
-
+        p_cmax,  p_rhq10,   p_micbnup,   o_GPP,  o_VEGC
+        1.215,   2.108,     0.432,       0.533,  5.112
     
+    with one column for each parameter and one column for each output.
+
+    ::
+
+      For each row in the sensitivity matrix (and corresponding run folder), 
+        For each variable specified in self.outputs:
+            - opens the NetCDF files that were output from dvmdostem
+            - grabs the last datapoint
+            - writes it to the sensitivity.csv file
 
     Parameters
     ----------
     posthoc : bool (Not implemented yet)
-      Flag for controlling whether this step should be run after the
-      model run or as part of the model run
+      Flag for controlling whether this step should be run after the model run
+      or as part of the model run
     
-    multi : bool (Not impolemented yet)
-      Flag for if the runs are done all in one directory or each in 
-      its own directory. If all runs are done in one directory
-      then paralleization is harder and this step of collating the
-      output data must be done at the end of the run before the next run
-      overwrites it.
+    multi : bool (Not implemented yet)
+      Flag for if the runs are done all in one directory or each in its own
+      directory. If all runs are done in one directory then paralleization is
+      harder and this step of collating the output data must be done at the end
+      of the run before the next run overwrites it.
       
-
     Returns
     -------
     None

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -242,37 +242,42 @@ class SensitivityDriver(object):
   def design_experiment(self, Nsamples, cmtnum, params, pftnums, 
       percent_diffs=None, sampling_method='lhc'):
     '''
-    Builds bounds based on initial values found in dvmdostem parameter 
-    files (cmt_*.txt files) and the `percent_diffs` array. 
-    The `percent_diffs` array gets used to figure out how far
-    the bounds should be from the initial value. Defaults to initial 
-    value +/-10%.
+    Builds bounds based on initial values found in dvmdostem parameter files
+    (cmt_*.txt files) and the `percent_diffs` array. The `percent_diffs` array
+    gets used to figure out how far the bounds should be from the initial value.
+    Defaults to initial value +/-10%.
 
     Sets instance values for `self.params` and `self.sample_matrix`.
 
     Parameters
     ----------
     Nsamples : int
-      How many samples to draw. One sample equates to one run to be done with 
+      How many samples to draw. One sample equates to one run to be done with
       the parameter values in the sample.
     
     cmtnum : int
-      Which community type number to use for initial parameter values, for
-      doing runs and analyzing outputs.
+      Which community type number to use for initial parameter values, for doing
+      runs and analyzing outputs.
     
     params : list of strings
-      List of parameter names to use in the experiment. Each name must be
-      in one of the dvmdostem parameter files (cmt_*.txt).
+      List of parameter names to use in the experiment. Each name must be in one
+      of the dvmdostem parameter files (cmt_*.txt).
     
-    pftnums : list of ints
-      List of PFT numbers, one number for each parameter in `params`. Use
-      `None` in the list for any non-pft parameter (i.e. a soil parameter).
+    pftnums : list, same length as params list
+      Each item in the items may be on of: 
+       1) int, 2) the string 'all', 3) list of ints, or 4) None.
+      If the list item is an int, then that is the PFT number to be used for the
+      corresponding parameter. If the list item is the string 'all' then ALL 10
+      PFTs are enabled for this parameter. If the list item is a list of ints,
+      then the corresponding parameter will be setup for each PFT in the list.
+      If the list item is None, then the parameter is assumed to be a soil
+      parameter and no PFT info is set or needed.
     
     percent_diffs : list of floats
-      List values, one for each parameter in `params`. The value is used to
-      the bounds with respect to the intial parameter value. I.e. passing
-      a value in the percent_diff array of .3 would mean that bounds should
-      be +/-30% of the initial value of the parameter.
+      List values, one for each parameter in `params`. The value is used to the
+      bounds with respect to the intial parameter value. I.e. passing a value in
+      the percent_diff array of .3 would mean that bounds should be +/-30% of
+      the initial value of the parameter.
     
     sampling_method : str
       A string indicating which sampling method to use for getting values for

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -269,7 +269,7 @@ class SensitivityDriver(object):
     initial parameter values.'''
     if path:
       self.work_dir = path
-      self.__initial_params_rundir = os.path.join(self.work_dir, 'initial_params_run_dir', 'parameters')
+      self.__initial_params_rundir = os.path.join(self.work_dir, 'initial_params_run_dir')
     else:
       self.work_dir = None
       self.__initial_params_rundir = None

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -417,13 +417,15 @@ class SensitivityDriver(object):
     -------
     None
     '''
-    try:
-      pft_verbose_name = pu.get_pft_verbose_name(
-        cmtnum=self.cmtnum(), pftnum=self.pftnum(), 
-        lookup_path=self.get_initial_params_dir()
-      )
-    except (AttributeError, ValueError) as e:
-      pft_verbose_name = ''
+    def lookup_pft_verbose_name(row):
+      if row.pftnum >= 0 and row.pftnum < 10:
+        pft_verbose_name = pu.get_pft_verbose_name(
+          cmtnum=self.cmtnum(), pftnum=row.pftnum, 
+          lookup_path=self.get_initial_params_dir()
+        )
+      else:
+        pft_verbose_name = None
+      return pft_verbose_name
 
     # Not all class attributes might be initialized, so if an 
     # attribute is not set, then print empty string.
@@ -434,6 +436,7 @@ class SensitivityDriver(object):
       # Might want to make this more specific to PFT column, 
       # in case there somehow ends up being bad data in one of the 
       # number columns that buggers things farther along?
+      df['PFT Name'] = df.apply(lookup_pft_verbose_name, axis=1)
       df = df.where(df.notna(), '')
       ps = df.to_string()
     except AttributeError:
@@ -447,16 +450,16 @@ class SensitivityDriver(object):
 
     info_str = textwrap.dedent('''\
       --- Setup ---
-      work_dir: {}
-      site: {}
-      pixel(y,x): ({},{})
-      cmtnum: {}
-      pftnum: {} ({})
-      sampling_method: {}
+      work_dir: {workdir}
+      site: {site}
+      pixel(y,x): ({pxY},{pxX})
+      cmtnum: {cmtnum}
+      sampling_method: {sampmeth}
 
       '''.format(
-        self.work_dir, self.site, self.PXy, self.PXx, self.cmtnum(),
-        '?', '?', self.sampling_method))
+        workdir=self.work_dir, site=self.site, 
+        pxY=self.PXy, pxX=self.PXx, cmtnum=self.cmtnum(),
+        sampmeth=self.sampling_method))
 
     info_str += textwrap.dedent('''\
       --- Parameters ---

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -214,12 +214,8 @@ class SensitivityDriver(object):
     clean : bool
       CAREFUL! - this will forecfully remove the entrire tree rooted at `work_dir`.
     '''
+    self.set_work_dir(work_dir) # this sets up the initial parameter directory
 
-    # Made this one private because I don't want it to get confused with 
-    # the later params directories that will be created in each run folder.
-    self.__initial_params = '/work/parameters'
-
-    self.work_dir = work_dir 
     self.site = '/data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_CALM_Toolik_LTER_10x10/'
     self.PXx = 0
     self.PXy = 0
@@ -234,6 +230,18 @@ class SensitivityDriver(object):
 
     if clean and work_dir is not None:
       self.clean()
+
+  def set_work_dir(self, path):
+    '''Sets the working directory for the object. Assumes that the working
+    directory will have an initial_value_run directory that will have the
+    initial parameter values.'''
+    if path:
+      self.work_dir = path
+      self.__initial_params = os.path.join(self.work_dir, 'initial_value_run', 'parameters')
+    else:
+      self.work_dir = None
+      self.__initial_params = None
+
 
   def get_initial_params_dir(self):
     '''Read only accessor to private member variable.'''

--- a/scripts/Sensitivity.py
+++ b/scripts/Sensitivity.py
@@ -204,45 +204,52 @@ class SensitivityDriver(object):
   '''
   Sensitivity Analysis Driver class.
 
-  Driver class for conducting dvmdostem SensitivityAnalysis.
+  Driver class for conducting ``dvmdostem`` SensitivityAnalysis.
   Methods for cleaning, setup, running model, collecting outputs.
 
   Basic overview of use is like this:
-   1. Instantiate driver object.
-   2. Setup/design the experiment (parameters, to use, 
-      number of samples, etc)
-   3. Use driver object to setup the run folders.
-   4. Use driver object to carry out model runs.
-   5. Use driver object to summarize/collect outputs.
-   6. Use driver object to make plots, do analysis.
+
+    1. Instantiate driver object.
+    2. Setup/design the experiment (working directory, seed path, parameters to 
+       use, number of samples, etc)
+    3. Use driver object to setup the run folders.
+    4. Use driver object to carry out model runs.
+    5. Use driver object to summarize/collect outputs.
+    6. Use driver object to make plots, do analysis.
+
 
   Parameters
   ----------
+  work_dir : str, optional
+    The working directory path of the driver object.
+
+  sampling_method : str one of {None, 'lhc','uniform'}, optional
+    The method by which the sample should be chosen. 
+
+  clean : bool, optional
+    CAREFUL! - this will forecfully remove the entrire tree rooted at `work_dir`.
+
 
   See Also
   --------
 
   Examples
   --------
-  Instantiate object, sets pixel, outputs, working directory, 
-  site selection (input data path)
+
   >>> driver = SensitivityDriver('/tmp/Sensitivity-inline-test')
   >>> driver.set_seed_path('/work/parameters')
-
-
 
   '''
   def __init__(self, work_dir=None, sampling_method=None, clean=False):
     '''
-    Constructor
+    Constructor.
+
     Hard code a bunch of stuff for now...
 
-    Parameters
-    ----------
-    work_dir : 
-
-    clean : bool
-      CAREFUL! - this will forecfully remove the entrire tree rooted at `work_dir`.
+    Returns
+    -------
+    SensitivityDriver
+      A constructed driver object.
     '''
     self.__seedpath = None
 
@@ -265,8 +272,8 @@ class SensitivityDriver(object):
 
   def set_work_dir(self, path):
     '''Sets the working directory for the object. Assumes that the working
-    directory will have an initial_params_rundir directory that will have the
-    initial parameter values.'''
+    directory will have an ``initial_params_rundir`` directory that will have
+    the initial parameter values.'''
     if path:
       self.work_dir = path
       self.__initial_params_rundir = os.path.join(self.work_dir, 'initial_params_run_dir')
@@ -307,8 +314,13 @@ class SensitivityDriver(object):
       of the dvmdostem parameter files (cmt_*.txt).
     
     pftnums : list, same length as params list
-      Each item in the items may be on of: 
-       1) int, 2) the string 'all', 3) list of ints, or 4) None.
+      Each item in the items may be one of: 
+
+       1. int 
+       2. the string 'all' 
+       3. list of ints 
+       4. None
+
       If the list item is an int, then that is the PFT number to be used for the
       corresponding parameter. If the list item is the string 'all' then ALL 10
       PFTs are enabled for this parameter. If the list item is a list of ints,
@@ -509,12 +521,21 @@ class SensitivityDriver(object):
     return info_str
 
   def core_setup(self, row, idx, initial=False):
-    '''
+    '''Sets up a sample run folder for the given ``idx`` and ``row``.
+
+    The following things are assumed:
+
+     - you have called set_working_directory()
+     - you have called set_seed_path()
+     - you have called designe experiment - OR you at least have:
+     - you have a sample_matrix
+     - you have a list of param specs
+
     Do all the work to setup and configure a model run.
     Uses the `row` parameter (one row of the sample matrix) to
     set the parameter values for the run.
 
-    Currently relies on command line API for various dvmdostem
+    Currently relies on command line API for various ``dvmdostem``
     helper scripts. Would be nice to transition to using a Python
     API for all these helper scripts (modules).
 
@@ -621,7 +642,7 @@ class SensitivityDriver(object):
     # iterate over the items in row, we need to find the parameter dict (out of
     # the self.params list) that matches the item in the row. The problem is
     # that in the parameter dict, pft is encoded with a key, where as in the
-    # row, it is a  mathced the item in the row...so we can look up the 
+    # row, it is an item in the row...so we can look up the 
     for rowkey, pval in row.items():
       pname, pft = rowkey2pdict(rowkey)
       for pdict in self.params:

--- a/scripts/doctests_Sensitivity.md
+++ b/scripts/doctests_Sensitivity.md
@@ -305,6 +305,33 @@ matrix.
 We could get fancy and write some loops to check all the rest of the parameters
 and sample folders but for now, we'll assume its working.
 
+    >>> # Clean up
+    >>> del(sd)
+
+# Check multi-pft functionality
+
+Next we can check that the multi-PFT functionality works:
+
+    >>> sd = Sensitivity.SensitivityDriver(clean=True)
+    >>> sd.set_work_dir('/tmp/tests-Sensitivity')
+    >>> sd.set_seed_path('/work/parameters')
+
+Here we are going to setup an experiment where `nfall(1)` is modified for 3
+different PFTs.
+
+    >>> sd.clean()
+    >>> sd.design_experiment(6, 5,
+    ...   params=['cmax','rhq10','nfall(1)'],
+    ...   pftnums=[1,None,[0,2,5]], 
+    ...   sampling_method='lhc')
+
+In this case we expect the sample matrix to have 6 rows, and 5 columns:
+
+    >>> sd.sample_matrix.shape
+    (6, 5)
+
+# Check runs
+
 The next step will be checking that running the samples works. At this time this
 is not practical because there is still too much data being printed to stdout to
 make the `doctest`s easy to write.


### PR DESCRIPTION
This adds the multi-pft capability to the SensitivityDriver object.

Previously it was restricted such that if you chose to include a PFT parameter, the same PFT had to be used across all parameters.

Now each parameter may have a list of associated PFTs to adjust. The lists need not be the same for different parameters. Some details are shown in the updated `doctests_Sensitivity.py` file.

There are still some questions about how the outputs should be handled and analyzed for these types of runs.