### PR TITLE
Address lack of winter respiration.

### DIFF
--- a/src/Soil_Bgc.cpp
+++ b/src/Soil_Bgc.cpp
@@ -586,14 +586,18 @@ void Soil_Bgc::deltac() {
   double ksomcr = 0.0;    // for CR SOM (in model, somcr)
 
   for (int il =0; il<cd->m_soil.numsl; il++) {
-
-    // Yuan: vwc normalized by total pore - this will allow
-    // respiration (methane/oxidation) implicitly
-    bd->m_soid.rhmoist[il] = getRhmoist( ed->m_soid.sws[il],
-                                         bgcpar.moistmin,
-                                         bgcpar.moistmax,
-                                         bgcpar.moistopt );
-
+    //HG: 01122023 - this condition allows for winter respiration
+    //(Natali et al. 2019, Nature Climate Change)
+    if (ed->m_sois.ts[il] <0.) {
+      bd->m_soid.rhmoist[il] = 1;
+    } else {
+      // Yuan: vwc normalized by total pore - this will allow
+      // respiration (methane/oxidation) implicitly
+      bd->m_soid.rhmoist[il] = getRhmoist( ed->m_soid.sws[il],
+                                           bgcpar.moistmin,
+                                           bgcpar.moistmax,
+                                           bgcpar.moistopt );
+    }
     bd->m_soid.rhq10[il] = getRhq10(ed->m_sois.ts[il]);
     krawc  = bgcpar.kdrawc[il];
     ksoma  = bgcpar.kdsoma[il];


### PR DESCRIPTION
Allow heterotrophic respiration during winter by lifting the limitation related to low soil moisture when tsoil<0.
The figure below represent a test run conducted at Eight Mile Lake (EML), AK, using the CMT05 (tussock tundra) parameterization, CRUTS4.0 climate forcing, 100 yrs pre-run, 1000 years equilibrium, 250 years spin-up and 115 years transient. It shown monthly ecosystem respiration (auto- and heterotrophic) over time. The grey line shown observations from the EML tower, the blue line represent model outputs without the modification, and the red line shows model outputs after the submitted modification. 
![WRF](https://user-images.githubusercontent.com/1791127/212201549-d98ec0e0-24ae-4301-9303-88bbddce1956.png)
