### PR TITLE
Express values for initfibthick and inithumthick as meters

### DIFF
--- a/parameters/cmt_dimground.txt
+++ b/parameters/cmt_dimground.txt
@@ -33,8 +33,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-5.4578             // initfibthick: meters
-10.9156            // inithumthick:
+0.054578             // initfibthick: meters
+0.109156            // inithumthick:
 0.012              // coefshlwa:
 1.18               // coefshlwb:
 0.008              // coefdeepa:
@@ -53,8 +53,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-4.98               // initfibthick: meters
-8.352              // inithumthick:
+0.0498               // initfibthick: meters
+0.08352              // inithumthick:
 0.019              // coefshlwa:
 1.125              // coefshlwb:
 0.0292             // coefdeepa:
@@ -73,8 +73,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-2.538              // initfibthick: meters
-5.076              // inithumthick:
+0.02538              // initfibthick: meters
+0.05076              // inithumthick:
 0.019              // coefshlwa:
 1.11               // coefshlwb:
 0.0292             // coefdeepa:


### PR DESCRIPTION
For forest community types (CMT01, CMT02, CMT03), values for `initfibthick` and `inithumthick` within cmt_dimground.txt were expressed in cm. The model calls for these values in meters, so convert accordingly.