### PR TITLE
Express values for initfibthick and inithumthick as meters for forest…

### DIFF
--- a/parameters/cmt_dimground.txt
+++ b/parameters/cmt_dimground.txt
@@ -33,8 +33,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-5.4578             // initfibthick: meters
-10.9156            // inithumthick:
+0.054578             // initfibthick: meters
+0.109156            // inithumthick:
 0.012              // coefshlwa:
 1.18               // coefshlwb:
 0.008              // coefdeepa:
@@ -53,8 +53,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-4.98               // initfibthick: meters
-8.352              // inithumthick:
+0.0498               // initfibthick: meters
+0.08352              // inithumthick:
 0.019              // coefshlwa:
 1.125              // coefshlwb:
 0.0292             // coefdeepa:
@@ -73,8 +73,8 @@
 0.02               // initdmossthick: initial dead moss thickness (m)
 1                  // mosstype: // moss type (1: sphagnum; 2: feathermoss; 3: other)
 // soil characteristics
-2.538              // initfibthick: meters
-5.076              // inithumthick:
+0.02538              // initfibthick: meters
+0.05076              // inithumthick:
 0.019              // coefshlwa:
 1.11               // coefshlwb:
 0.0292             // coefdeepa:


### PR DESCRIPTION
… community types.

Renamed branch to match the file being changed. And to experiment with the renaming process....
When you re-name it automatically closes associated PRs, in this case #539.

I have pasted the discussion from #539 here:

For forest community types (CMT01, CMT02, CMT03), values for initfibthick and inithumthick within cmt_dimground.txt were expressed in cm. The model calls for these values in meters, so convert accordingly.


Setup a little test as follows:

```bash
$ CASE="test-PR539"

$ setup_working_directory.py --input-data-path /data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_BNZ-LTER_CRREL_Met_10x10/ /data/workflows/$CASE

$ cd /data/workflows/$CASE

$ outspec_utils.py --empty config/output_spec.csv 

$ outspec_utils.py config/output_spec.csv --on ALD y
$ outspec_utils.py config/output_spec.csv --on TSHLW m
$ outspec_utils.py config/output_spec.csv --on TDEEP m
$ outspec_utils.py config/output_spec.csv --on DEEPC m
$ outspec_utils.py config/output_spec.csv --on SHLWC m
$ outspec_utils.py config/output_spec.csv --on GPP m
$ outspec_utils.py config/output_spec.csv --on CMTNUM y

#ncdump /data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_BNZ-LTER_CRREL_Met_10x10/vegetation.nc
# find pixels with correct CMT, in this case, 1, 2, 3

$ runmask-util.py --reset run-mask.nc
$ runmask-util.py   --yx 1 8  run-mask.nc
$ runmask-util.py   --yx 1 7  run-mask.nc
$ runmask-util.py   --yx 0 0   run-mask.nc

$ dvmdostem -l err -p 100 -e 1000 -s 250 -t 115 -n 85

$ cd .. 
```

Repeat the above steps for `CASE="test-master"` **REMEMBER TO CHANGE BRANCHES!**

Then do the following:
```bash
$ mkdir -p "test-PR539/plots"

$ ipython
```
And at the Python prompt, do the following:
```python
import sys
sys.path.insert(0, '/work/scripts')
import output_utils
import netCDF4 as nc
import matplotlib.pyplot as plt


def make_comparison_plot(var, timeres, tailsize=24):
  master, units  = output_utils.stitch_stages(var=var, timestep=timeres, stages='sp tr sc'.split(), fileprefix='test-PR539-master/output')
  pr539, units = output_utils.stitch_stages(var=var, timestep=timeres, stages='sp tr sc'.split(), fileprefix='test-PR539/output')
  fig = plt.figure(figsize=(12,8))
  axes = fig.subplots(3,3)
  pixels = [(1,8),(1,7),(0,0)]
  for i, (y,x) in enumerate(pixels):
      ax = axes[i,0]
      ax.sharex(axes[0,0])
      ax.plot(master[:,y,x], color='black', linewidth=2, label='master')
      ax.plot(pr539[:,y,x], color='red', linewidth=2, label='pr539')
      ax.set_ylabel(f"{var} {units}")
      ax.set_title(f"px(y,x):({y},{x})")
      ax.legend()

      ax = axes[i,1]
      ax.sharex(axes[0,1])
      ax.plot(master[0:10,y,x], color='black', linewidth=2, label='master')
      ax.plot(pr539[0:10:,y,x], color='red', linewidth=2, label='pr539')
      ax.set_title(f"px(y,x):({y},{x})")
      ax.legend()

      ax = axes[i,2]
      ax.sharex(axes[0,2])
      ax.plot(range(master.shape[0]-tailsize, master.shape[0]), master[-tailsize:,y,x], color='black', linewidth=2, label='master')
      ax.plot(range(master.shape[0]-tailsize, master.shape[0]), pr539[-tailsize:,y,x], color='red', linewidth=2, label='pr539')
      ax.set_title(f"px(y,x):({y},{x})")
      ax.legend()


  plt.tight_layout()    
  plt.savefig(f'test-PR539/plots/{var}.png')
  plt.show()

for var in 'ALD'.split():
  timeres = 'yearly'
  make_comparison_plot(var, timeres)

for var in 'TSHLW TDEEP SHLWC DEEPC GPP'.split():
  timeres = 'monthly'
  make_comparison_plot(var, timeres)
```


* Left column is the full time series, (spinup, transient, scenario), 
 * middle column is the initial 24 time steps (years or month, depending on the variable) and 
 * right column is the final 24 time steps.

### **ALD**
![ALD](https://user-images.githubusercontent.com/838735/217398153-58f21b91-6f4a-424b-ad1b-ba75bde9485b.png)

### **DEEPC**
![DEEPC](https://user-images.githubusercontent.com/838735/217398162-e06b2296-0e77-4787-9524-31a5be07d044.png)

### **GPP**
![GPP](https://user-images.githubusercontent.com/838735/217398168-c3282928-105a-415c-a8f8-7e25ed3f2dcd.png)

### **SHLWC**
![SHLWC](https://user-images.githubusercontent.com/838735/217398171-d597a14b-e824-4677-84ae-66c1fc72afbd.png)

### **TDEEP**
![TDEEP](https://user-images.githubusercontent.com/838735/217398177-ea5ea87f-bb5c-495a-98cb-f6682c63e828.png)

### **TSHLW**
![TSHLW](https://user-images.githubusercontent.com/838735/217398179-43cc0234-1118-4933-b48d-29ff3b3c78e9.png)
