### PR TITLE
Cleanup from last several PRs so that tests pass:

### DIFF
--- a/parameters/cmt_envcanopy.txt
+++ b/parameters/cmt_envcanopy.txt
@@ -165,7 +165,7 @@
 0.00001     0.00001     0.00001      0.00001      0.00001      0.00001      0.00001      0.00001      0.00001      0.00001          // gl_c:  cuticular conductance
 930         930         930          930          930          930          930          930          930          930              // vpd_open:  vpd (pa) for leaf stomata fully openness
 4100        4100        4100         4100         4100         4100         4100         4100         4100         4100             // vpd_close: vpd (pa) for leaf stomata fully closure
-75          75          75           75           75           75           75           75           75           75               // ppfd50::
+75          75          75           75           75           75           75           75           75           75               // ppfd50:
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegwater: initial intercepted rain water in canopy
 0.0         0.0         0.0          0.0          0.0          0.0          0.0          0.0          0.0          0.0              // initvegsnow: initial intercepted snow water in canopy
 //===========================================================

--- a/scripts/doctests_param_util.md
+++ b/scripts/doctests_param_util.md
@@ -43,6 +43,7 @@ which we can print the name and number of each CMT.
     12 Lowland Boreal Wet Shrubland
     20 EML Shrub Tundra
     21 EML Tussock Tundra
+    31 Boreal Bog
     44 Shrub Tundra Kougarok
 
 Build a lookup table, mapping file names to lists of available parameters
@@ -57,18 +58,18 @@ See that all the parameter files contain the same CMTs (by number):
     >>> import os
     >>> for f in os.listdir("../parameters/"):
     ...   print([i["cmtnum"] for i in pu.get_CMTs_in_file("../parameters/" + f)])
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
-    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
+    [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]
 
 Enforce that all the CMT verbose names are identical across files.
 
-    >>> for cmt in [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 44]:
+    >>> for cmt in [0, 1, 2, 3, 4, 5, 6, 7, 12, 20, 21, 31, 44]:
     ...   names = []
     ...   for f in os.listdir("../parameters/"):
     ...     dd = pu.cmtdatablock2dict(pu.get_CMT_datablock("../parameters/" + f, cmt))
@@ -90,6 +91,7 @@ Enforce that all the CMT verbose names are identical across files.
     cmt 12: OK
     cmt 20: OK
     cmt 21: OK
+    cmt 31: OK
     cmt 44: OK
 
 Check on one of the command line reporting fuctions:

--- a/scripts/doctests_qcal.md
+++ b/scripts/doctests_qcal.md
@@ -94,8 +94,8 @@ targets:
             targets file: /tmp/dvmdostem-doctests-qcal/calibration
          parameter files: /tmp/dvmdostem-doctests-qcal/parameters
                      CMT: {'CMT05'}
-                     QCR: 44.19473466493039
-            Weighted QCR: 1.3323120712593841
+                     QCR: 65.31246965588963
+            Weighted QCR: 22.29921752995369
     <BLANKLINE> 
 
 The NetCDF and json reports should in theory match exactly, but there is
@@ -107,8 +107,8 @@ frequently a little variation due to rounding errors.
             targets file: /tmp/dvmdostem-doctests-qcal/calibration
          parameter files: /tmp/dvmdostem-doctests-qcal/parameters
                      CMT: {'CMT05'}
-                     QCR: 44.19473466493039
-            Weighted QCR: 1.3323120712593834
+                     QCR: 65.31246965588963
+            Weighted QCR: 22.299217529953683
     <BLANKLINE>    
 
 


### PR DESCRIPTION
- When adding CMT31, forgot to update tests.
- Recent update to CMT21 had bad formatting for parameter name.