### PR TITLE
Fix restart

### DIFF
--- a/include/Ground.h
+++ b/include/Ground.h
@@ -185,6 +185,7 @@ private :
 
   void cleanSnowSoilLayers();
   void cleanAllLayers();
+  void cleanRockLayers();
 
 };
 

--- a/include/layerconst.h
+++ b/include/layerconst.h
@@ -22,7 +22,8 @@ const double ROCKTHICK[MAX_ROC_LAY] = {2.0, 4.0, 8.0, 16.0, 20.0};
 // maximum number of soil layer
 const int MAX_SOI_LAY = MAX_MOS_LAY + MAX_SLW_LAY + MAX_DEP_LAY + MAX_MIN_LAY;
 //maximumum number of Ground (soil+rock+snow) Layer
-const int MAX_GRN_LAY = MAX_SNW_LAY + MAX_SOI_LAY+ MAX_ROC_LAY;
+const int MAX_GRN_LAY = MAX_SNW_LAY + MAX_SOI_LAY + MAX_ROC_LAY;
+//const int MAX_GRN_LAY = MAX_SNW_LAY + MAX_SOI_LAY;
 
 const int MAX_NUM_FNT = 10; //maximum number of fronts in all ground layers
 

--- a/include/layerconst.h
+++ b/include/layerconst.h
@@ -21,9 +21,9 @@ const double ROCKTHICK[MAX_ROC_LAY] = {2.0, 4.0, 8.0, 16.0, 20.0};
 
 // maximum number of soil layer
 const int MAX_SOI_LAY = MAX_MOS_LAY + MAX_SLW_LAY + MAX_DEP_LAY + MAX_MIN_LAY;
-//maximumum number of Ground (soil+rock+snow) Layer
+
+// maximumum number of Ground (soil+rock+snow) Layers
 const int MAX_GRN_LAY = MAX_SNW_LAY + MAX_SOI_LAY + MAX_ROC_LAY;
-//const int MAX_GRN_LAY = MAX_SNW_LAY + MAX_SOI_LAY;
 
 const int MAX_NUM_FNT = 10; //maximum number of fronts in all ground layers
 

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -278,9 +278,7 @@ void Cohort::initialize_state_parameters() {
 
   // Set-up the snow-soil-soilparent structure
   // snow updated daily, while soil dimension at monthly
-//  BOOST_LOG_SEV(glg, fatal) << "init before layer struc" ;
   ground.initLayerStructure(&cd.d_snow, &cd.m_soil);
-//  BOOST_LOG_SEV(glg, fatal) << "init after layer struc" ;
 
   cd.d_soil = cd.m_soil;
 
@@ -644,9 +642,6 @@ void Cohort::updateMonthly_Env(const int & currmind, const int & dinmcurr) {
     // save the variables to daily 'edall' (Note: not PFT specified)
     soilenv.retrieveDailyTM(ground.toplayer, ground.lstsoill);
 
-    //assuming rock layer's temperature equal to that of lstsoill
-//    solprntenv.retrieveDailyTM(ground.lstsoill);
-
     //Propogates some daily values (specifically Front data)
     // into edall from each ed
     getEd4allgrnd_daily();
@@ -856,10 +851,8 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai
   // tentatively set to a common age from 'ysf' - year since fire -
   //   should have more varability based on PFT types
   for (int ip=0; ip<NUM_PFT; ip++) {
-//    BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd.m_veg.vegage[ip];
     if (cd.m_veg.vegcov[ip]>0.) {
       cd.m_veg.vegage[ip] = cd.yrsdist;
-//      BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd.m_veg.vegage[ip] << ", yrsdist: " << cd.yrsdist;
       if (cd.m_veg.vegage[ip]<=0) {
         cd.m_vegd.foliagemx[ip] = 0.;
       }
@@ -1388,8 +1381,6 @@ void Cohort::set_restartdata_from_state() {
   // clear the restartdata object
   restartdata.reinitValue();
   
-//  restartdata.chtid = cd.chtid;  // deprecate?
-
   // atm
   restartdata.dsr                = edall->d_atms.dsr;
   restartdata.firea2sorgn        = fd->fire_a2soi.orgn; // to re-deposit fire-emitted N in one FRI

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -278,7 +278,9 @@ void Cohort::initialize_state_parameters() {
 
   // Set-up the snow-soil-soilparent structure
   // snow updated daily, while soil dimension at monthly
+//  BOOST_LOG_SEV(glg, fatal) << "init before layer struc" ;
   ground.initLayerStructure(&cd.d_snow, &cd.m_soil);
+//  BOOST_LOG_SEV(glg, fatal) << "init after layer struc" ;
 
   cd.d_soil = cd.m_soil;
 
@@ -656,6 +658,7 @@ void Cohort::updateMonthly_Env(const int & currmind, const int & dinmcurr) {
 
     //update Snow structure at daily timestep (for soil structure
     //  at yearly timestep in ::updateMonthly_DIMgrd)
+    ground.retrieveSnowDimension(&cd.d_snow);
     ground.retrieveSnowDimension(&cd.d_snow);
 
     cd.endOfDay(dinmcurr); //this must be done first, because it's needed below
@@ -1347,11 +1350,12 @@ void Cohort::set_state_from_restartdata() {
                            << "values from the RestartData object...";
 
   veg.set_state_from_restartdata(this->restartdata);
-  solprntenv.set_state_from_restartdata(this->restartdata);
-  fire.set_state_from_restartdata(this->restartdata);
+  ground.set_state_from_restartdata(&cd.d_snow, &cd.m_soil, this->restartdata);
   snowenv.set_state_from_restartdata(this->restartdata);
   soilenv.set_state_from_restartdata(this->restartdata);
+  solprntenv.set_state_from_restartdata(this->restartdata);
   soilbgc.set_state_from_restartdata(this->restartdata);
+  fire.set_state_from_restartdata(this->restartdata);
 
   for(int ii=0; ii<NUM_PFT; ii++){
     vegbgc[ii].set_state_from_restartdata(this->restartdata);
@@ -1383,7 +1387,7 @@ void Cohort::set_restartdata_from_state() {
   // clear the restartdata object
   restartdata.reinitValue();
   
-  restartdata.chtid = cd.chtid;  // deprecate?
+//  restartdata.chtid = cd.chtid;  // deprecate?
 
   // atm
   restartdata.dsr                = edall->d_atms.dsr;
@@ -1513,6 +1517,7 @@ void Cohort::set_restartdata_from_state() {
     restartdata.somcr[il] = bdall->m_sois.somcr[il];
     restartdata.orgn[il] = bdall->m_sois.orgn[il];
     restartdata.avln[il] = bdall->m_sois.avln[il];
+    
     deque<double> tmpdeque = bdall->prvltrfcnque[il];
     int recnum = tmpdeque.size();
 

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -645,7 +645,7 @@ void Cohort::updateMonthly_Env(const int & currmind, const int & dinmcurr) {
     soilenv.retrieveDailyTM(ground.toplayer, ground.lstsoill);
 
     //assuming rock layer's temperature equal to that of lstsoill
-    solprntenv.retrieveDailyTM(ground.lstsoill);
+//    solprntenv.retrieveDailyTM(ground.lstsoill);
 
     //Propogates some daily values (specifically Front data)
     // into edall from each ed

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -856,9 +856,10 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai
   // tentatively set to a common age from 'ysf' - year since fire -
   //   should have more varability based on PFT types
   for (int ip=0; ip<NUM_PFT; ip++) {
+//    BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd.m_veg.vegage[ip];
     if (cd.m_veg.vegcov[ip]>0.) {
       cd.m_veg.vegage[ip] = cd.yrsdist;
-
+//      BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd.m_veg.vegage[ip] << ", yrsdist: " << cd.yrsdist;
       if (cd.m_veg.vegage[ip]<=0) {
         cd.m_vegd.foliagemx[ip] = 0.;
       }

--- a/src/CohortData.cpp
+++ b/src/CohortData.cpp
@@ -32,7 +32,7 @@ CohortData::~CohortData() {
 
 // initialize CohortData class explicitly
 void CohortData::clear() {
-  chtid = MISSING_I;
+//  chtid = MISSING_I;
   year  = MISSING_I;
   month = MISSING_I;
   cmttype = MISSING_I;

--- a/src/CohortData.cpp
+++ b/src/CohortData.cpp
@@ -32,7 +32,6 @@ CohortData::~CohortData() {
 
 // initialize CohortData class explicitly
 void CohortData::clear() {
-//  chtid = MISSING_I;
   year  = MISSING_I;
   month = MISSING_I;
   cmttype = MISSING_I;

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -434,6 +434,19 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
   //needs to clean up old 'ground'
   cleanAllLayers();
   //
+  //test if any layer is remaining
+  Layer* current_layer = this->toplayer;
+  int extra = 0;
+  if (current_layer == NULL) {
+    BOOST_LOG_SEV(glg, err) << " (No Layers left...)";
+  } else {
+    BOOST_LOG_SEV(glg, err) << " (Remaining Layers...)";
+    while(current_layer!=NULL) {
+      ++extra;
+      current_layer = current_layer->nextl;
+    }
+  }
+//  BOOST_LOG_SEV(glg, err) << "number of old rock Layers " << extra ;
   soilparent.num = 0;
   soilparent.thick = 0.;
 
@@ -447,6 +460,12 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
   for(int il =soilparent.num-1; il>=0; il--) {
     ParentLayer* rl = new ParentLayer(soilparent.dz[il]);
     insertFront(rl);
+  }
+
+  // Clean extra bottom rock layers if any
+  for(int il =soilparent.num-1+extra; il>soilparent.num-1; il--) {
+    BOOST_LOG_SEV(glg, err) << "after parent layers :" << il;
+    cleanRockLayers(); 
   }
 
   rocklayercreated = true;
@@ -2349,6 +2368,19 @@ void Ground::cleanAllLayers() {
     currl = templ ;
   }
 }
+
+void Ground::cleanRockLayers() {
+  Layer* currl = botlayer;
+  Layer* templ;
+
+  while(currl!=NULL) {
+    templ = currl->nextl;
+    removeLayer(currl);
+    currl = templ ;
+  }
+
+}
+
 
 //////////////////////////////////////////////////////////////////////
 

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -432,20 +432,12 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
                                    soistate_dim *soildim,
                                    const RestartData & rdata) {
 
-//  BOOST_LOG_SEV(glg, err) << "before cleanup :"
-//                              << layer_report_string("depth thermal ptr");
-
-  //needs to clean up old 'ground'
-  // This cleaning up will keep the bottom layer of the profile - 
-  //if one try to force deleting it, one would get a seg fault. 
-  // So let's try to delete this old bottom layer after new rock 
-  //layers have been created.
+  // This cleaning up will keep the bottom layer of the profile - if one try to
+  // force deleting it, one would get a seg fault. So let's try to delete this
+  // old bottom layer after new rock 
   cleanAllLayers();
   
-//  BOOST_LOG_SEV(glg, err) << "after cleanup :"
-//                              << layer_report_string("depth thermal ptr");
-
-  //test if any layer is remaining
+  // test if any layer is remaining
   Layer* current_layer = this->toplayer;
   int extra = 0;
   if (current_layer == NULL) {
@@ -457,7 +449,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
       current_layer = current_layer->nextl;
     }
   }
-//  BOOST_LOG_SEV(glg, err) << "number of old rock Layers " << extra ;
 
   soilparent.num = 0;
   soilparent.thick = 0.;
@@ -474,18 +465,12 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     insertFront(rl);
   }
 
-//  BOOST_LOG_SEV(glg, err) << "after parent layers :"
-//                              << layer_report_string("depth thermal ptr");
-
   // Clean extra bottom rock layers if any
-  for(int il =soilparent.num-1+extra; il>soilparent.num-1; il--) {
+  for(int il = soilparent.num-1+extra; il>soilparent.num-1; il--) {
     BOOST_LOG_SEV(glg, err) << "after parent layers :" << il;
     cleanRockLayers(); 
   }
 
-//  BOOST_LOG_SEV(glg, err) << "after second cleanup :"
-//                              << layer_report_string("depth thermal ptr");
- 
   rocklayercreated = true;
   //
   int soiltype[MAX_SOI_LAY];
@@ -500,9 +485,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     frozen[i]      = rdata.FROZENsoil[i];
   }
 
-//  BOOST_LOG_SEV(glg, err) << "after soil layers1 :"
-//                              << layer_report_string("depth thermal ptr");
-
   mineralinfo.set5Soilprofile(soiltype, dzsoil, MAX_SOI_LAY);
 
   for(int il =mineralinfo.num-1; il>=0; il--) {
@@ -516,8 +498,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     ml->frozen = frozen[il];
     insertFront(ml);
   }
-//  BOOST_LOG_SEV(glg, err) << "after soil layers2 :"
-//                              << layer_report_string("depth thermal ptr");
 
   organic.assignDeepThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
@@ -536,8 +516,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     pl->frozen = frozen[il];
     insertFront(pl);
   }
-//  BOOST_LOG_SEV(glg, err) << "after organic layers2 :"
-//                              << layer_report_string("depth thermal ptr");
 
   moss.setThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
@@ -547,8 +525,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     ml->frozen = frozen[il];
     insertFront(ml);
   }
-//  BOOST_LOG_SEV(glg, err) << "after moss layers1 :"
-//                              << layer_report_string("depth thermal ptr");
 
   //snow
   snow.coverage  = 0.;
@@ -572,9 +548,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     }
   }
 
-//  BOOST_LOG_SEV(glg, err) << "after snow layers1 :"
-//                              << layer_report_string("depth thermal ptr");
-
   //
   frontsz.clear();
   frontstype.clear();
@@ -592,9 +565,6 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
       frontstype.push_front(frontFT[ifnt]);
     }
   }
-
-//  BOOST_LOG_SEV(glg, err) << "after fronts :"
-//                              << layer_report_string("depth thermal ptr");
 
   //
   resortGroundLayers();

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -330,12 +330,15 @@ void Ground::initLayerStructure(snwstate_dim *snowdim, soistate_dim *soildim) {
   // Needs to clean up old 'ground', if any
   cleanAllLayers();
 
+  rocklayercreated = false;
+
   // Layers are constructed from bottom
   if(rocklayercreated) {
     cleanSnowSoilLayers();
   } else {
     initRockLayers(); // Rock in the bottom first and no-need to do again
   }
+
 
   initSnowSoilLayers();
   resortGroundLayers();

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -431,9 +431,20 @@ void Ground::initSnowSoilLayers() {
 void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
                                    soistate_dim *soildim,
                                    const RestartData & rdata) {
+
+//  BOOST_LOG_SEV(glg, err) << "before cleanup :"
+//                              << layer_report_string("depth thermal ptr");
+
   //needs to clean up old 'ground'
+  // This cleaning up will keep the bottom layer of the profile - 
+  //if one try to force deleting it, one would get a seg fault. 
+  // So let's try to delete this old bottom layer after new rock 
+  //layers have been created.
   cleanAllLayers();
-  //
+  
+//  BOOST_LOG_SEV(glg, err) << "after cleanup :"
+//                              << layer_report_string("depth thermal ptr");
+
   //test if any layer is remaining
   Layer* current_layer = this->toplayer;
   int extra = 0;
@@ -447,6 +458,7 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     }
   }
 //  BOOST_LOG_SEV(glg, err) << "number of old rock Layers " << extra ;
+
   soilparent.num = 0;
   soilparent.thick = 0.;
 
@@ -462,12 +474,18 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     insertFront(rl);
   }
 
+//  BOOST_LOG_SEV(glg, err) << "after parent layers :"
+//                              << layer_report_string("depth thermal ptr");
+
   // Clean extra bottom rock layers if any
   for(int il =soilparent.num-1+extra; il>soilparent.num-1; il--) {
     BOOST_LOG_SEV(glg, err) << "after parent layers :" << il;
     cleanRockLayers(); 
   }
 
+//  BOOST_LOG_SEV(glg, err) << "after second cleanup :"
+//                              << layer_report_string("depth thermal ptr");
+ 
   rocklayercreated = true;
   //
   int soiltype[MAX_SOI_LAY];
@@ -482,6 +500,9 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     frozen[i]      = rdata.FROZENsoil[i];
   }
 
+//  BOOST_LOG_SEV(glg, err) << "after soil layers1 :"
+//                              << layer_report_string("depth thermal ptr");
+
   mineralinfo.set5Soilprofile(soiltype, dzsoil, MAX_SOI_LAY);
 
   for(int il =mineralinfo.num-1; il>=0; il--) {
@@ -495,6 +516,8 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     ml->frozen = frozen[il];
     insertFront(ml);
   }
+//  BOOST_LOG_SEV(glg, err) << "after soil layers2 :"
+//                              << layer_report_string("depth thermal ptr");
 
   organic.assignDeepThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
@@ -513,6 +536,8 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     pl->frozen = frozen[il];
     insertFront(pl);
   }
+//  BOOST_LOG_SEV(glg, err) << "after organic layers2 :"
+//                              << layer_report_string("depth thermal ptr");
 
   moss.setThicknesses(soiltype, dzsoil, MAX_SOI_LAY);
 
@@ -522,6 +547,8 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     ml->frozen = frozen[il];
     insertFront(ml);
   }
+//  BOOST_LOG_SEV(glg, err) << "after moss layers1 :"
+//                              << layer_report_string("depth thermal ptr");
 
   //snow
   snow.coverage  = 0.;
@@ -545,6 +572,9 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
     }
   }
 
+//  BOOST_LOG_SEV(glg, err) << "after snow layers1 :"
+//                              << layer_report_string("depth thermal ptr");
+
   //
   frontsz.clear();
   frontstype.clear();
@@ -562,6 +592,9 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
       frontstype.push_front(frontFT[ifnt]);
     }
   }
+
+//  BOOST_LOG_SEV(glg, err) << "after fronts :"
+//                              << layer_report_string("depth thermal ptr");
 
   //
   resortGroundLayers();

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -42,7 +42,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
   // create types for all the dimensions in the RestartData object...
   const int elems_in_restartdata = 63;
   int counts[elems_in_restartdata] = {
-//    1, // int chtid;
     1, // int dsr;
     1, // double firea2sorgn;
     1, // int yrsdist;
@@ -105,7 +104,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MAX_SOI_LAY, // double ICEsoil[MAX_SOI_LAY];
     MAX_SOI_LAY, // int FROZENsoil[MAX_SOI_LAY];
     MAX_SOI_LAY, // double FROZENFRACsoil[MAX_SOI_LAY];
-//    MAX_SOI_LAY, // int TEXTUREsoil[MAX_SOI_LAY];
     
     MAX_ROC_LAY, // double TSrock[MAX_ROC_LAY];
     MAX_ROC_LAY, // double DZrock[MAX_ROC_LAY];
@@ -128,7 +126,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     12 * MAX_SOI_LAY // double prvltrfcnA[12][MAX_SOI_LAY];   //previous 12-month litterfall (root death) input C/N ratios in each soil layer for adjusting 'kd'
   };
   MPI_Datatype old_types[elems_in_restartdata] = {
-//    MPI_INT, // int chtid;
     MPI_INT, // int dsr;
     MPI_DOUBLE, // double firea2sorgn;
     MPI_INT, // int yrsdist;
@@ -179,7 +176,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MPI_DOUBLE, // double ICEsoil[MAX_SOI_LAY];
     MPI_INT, // int FROZENsoil[MAX_SOI_LAY];
     MPI_DOUBLE, // double FROZENFRACsoil[MAX_SOI_LAY];
-//    MPI_INT, // int TEXTUREsoil[MAX_SOI_LAY];
     MPI_DOUBLE, // double TSrock[MAX_ROC_LAY];
     MPI_DOUBLE, // double DZrock[MAX_ROC_LAY];
     MPI_DOUBLE, // double frontZ[MAX_NUM_FNT];
@@ -195,7 +191,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MPI_DOUBLE // double prvltrfcnA[12][MAX_SOI_LAY];
   };
   MPI_Aint displacements[elems_in_restartdata] = {
-//    offsetof(RestartData, chtid),
     offsetof(RestartData, dsr),
     offsetof(RestartData, firea2sorgn),
     offsetof(RestartData, yrsdist),
@@ -246,7 +241,6 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     offsetof(RestartData, ICEsoil),
     offsetof(RestartData, FROZENsoil),
     offsetof(RestartData, FROZENFRACsoil),
-//    offsetof(RestartData, TEXTUREsoil),
     offsetof(RestartData, TSrock),
     offsetof(RestartData, DZrock),
     offsetof(RestartData, frontZ),
@@ -275,12 +269,10 @@ MPI_Datatype RestartData::register_mpi_datatype() {
 #endif
 
 void RestartData::reinitValue() {
-  //
-//  chtid = MISSING_I;
-  // atm
+  // atmosphere
   dsr         = MISSING_I;
   firea2sorgn = MISSING_D;
-  //vegegetation
+  // vegetation
   yrsdist     = MISSING_I;
 
   for (int ip=0; ip<NUM_PFT; ip++) {
@@ -361,7 +353,6 @@ void RestartData::reinitValue() {
     ICEsoil[il]  = MISSING_D;
     FROZENsoil[il]= MISSING_I;
     FROZENFRACsoil[il]= MISSING_D;
-//    TEXTUREsoil[il]   = MISSING_I;
   }
 
   for(int il =0; il<MAX_ROC_LAY; il++) {
@@ -468,7 +459,6 @@ void RestartData::verify_logical_values(){
   //whether or not it makes sense for that value to have been initialized
   //to a low negative.
 
-//  check_bounds("chtid", chtid);
   check_bounds("dsr", dsr);
   check_bounds("firea2sorgn", firea2sorgn);
   check_bounds("yrsdist", yrsdist);
@@ -534,7 +524,6 @@ void RestartData::verify_logical_values(){
     check_bounds("ICEsoil", ICEsoil[ii]);
     check_bounds("FROZENsoil", FROZENsoil[ii]);
     check_bounds("FROZENFRACsoil", FROZENFRACsoil[ii]);
-//    check_bounds("TEXTUREsoil", TEXTUREsoil[ii]);
     check_bounds("rawc", rawc[ii]);
     check_bounds("soma", soma[ii]);
     check_bounds("sompr", sompr[ii]);
@@ -793,15 +782,12 @@ void RestartData::read_px_soil_vars(const std::string& fname, const int rowidx, 
   count[1] = 1;
   count[2] = MAX_SOI_LAY;
 
-
   temutil::nc( nc_inq_varid(ncid, "TYPEsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &TYPEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "AGEsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &AGEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "FROZENsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &FROZENsoil[0]) );
-//  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
-//  temutil::nc( nc_get_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
 
   temutil::nc( nc_inq_varid(ncid, "DZsoil", &cv) );
   temutil::nc( nc_get_vara_double(ncid, cv, start, count, &DZsoil[0]) );
@@ -886,8 +872,11 @@ void RestartData::read_px_front_vars(const std::string& fname, const int rowidx,
 
 }
 
-/**  Reads arrays for variables with dimensions (Y, X, prev<XX>, pft).
-* Used for variables that need the previous 10 or 12 values.
+/**  Reads arrays for variables with dimensions (Y, X, prev<XX>, pft). Used for
+* variables that need the previous 10 or 12 values. 
+*
+* Note: The name of this function is somewhat misleading as it also handles one
+* soil variable!
 */
 void RestartData::read_px_prev_pft_vars(const std::string& fname, const int rowidx, const int colidx) {
   int ncid;
@@ -916,10 +905,7 @@ void RestartData::read_px_prev_pft_vars(const std::string& fname, const int rowi
   temutil::nc( nc_inq_varid(ncid, "unnormleafmxA", &cv) );
   temutil::nc( nc_get_vara_double(ncid, cv, start, count, &unnormleafmxA[0][0]) );
 
-//  count[2] = 12;           // <-- previous 12 months?...
-//  temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
-//  temutil::nc( nc_get_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
-
+  // Adjust offsets for use with monthly soil variable.
   count[2] = 12;        // <-- previous 12 months
   count[3] = MAX_SOI_LAY;
 
@@ -1126,12 +1112,9 @@ void RestartData::create_empty_file(const std::string& fname,
   vartype3D_dimids[2] = soillayerD;
 
   // Setup 3D vars, integer
-//  int TEXTUREsoilV;
   int FROZENsoilV;
   int TYPEsoilV;
   int AGEsoilV;
-//  temutil::nc( nc_def_var(ncid, "TEXTUREsoil", NC_INT, 3, vartype3D_dimids, &TEXTUREsoilV) );
-//  temutil::nc( nc_put_att_int(ncid, TEXTUREsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
   temutil::nc( nc_def_var(ncid, "FROZENsoil", NC_INT, 3, vartype3D_dimids, &FROZENsoilV) );
   temutil::nc( nc_put_att_int(ncid, FROZENsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
   temutil::nc( nc_def_var(ncid, "TYPEsoil", NC_INT, 3, vartype3D_dimids, &TYPEsoilV) );
@@ -1140,17 +1123,17 @@ void RestartData::create_empty_file(const std::string& fname,
   temutil::nc( nc_put_att_int(ncid, AGEsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
 
   // Setup 3D vars, double
-  int  TSsoilV;
-  int  DZsoilV;
-  int  LIQsoilV;
-  int  ICEsoilV;
-  int  FROZENFRACsoilV;
-  int  rawcV;
-  int  somaV;
-  int  somprV;
-  int  somcrV;
-  int  orgnV;
-  int  avlnV;
+  int TSsoilV;
+  int DZsoilV;
+  int LIQsoilV;
+  int ICEsoilV;
+  int FROZENFRACsoilV;
+  int rawcV;
+  int somaV;
+  int somprV;
+  int somcrV;
+  int orgnV;
+  int avlnV;
   temutil::nc( nc_def_var(ncid, "TSsoil", NC_DOUBLE, 3, vartype3D_dimids, &TSsoilV) );
   temutil::nc( nc_put_att_double(ncid, TSsoilV, "_FillValue", NC_DOUBLE, 1, &MISSING_D) );
   temutil::nc( nc_def_var(ncid, "DZsoil", NC_DOUBLE, 3, vartype3D_dimids, &DZsoilV) );
@@ -1556,8 +1539,6 @@ void RestartData::write_px_soil_vars(const std::string& fname, const int rowidx,
   temutil::nc( nc_put_vara_int(ncid, cv, start, count, &AGEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "FROZENsoil", &cv) );
   temutil::nc( nc_put_vara_int(ncid, cv, start, count, &FROZENsoil[0]) );
-//  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
-//  temutil::nc( nc_put_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
   
   temutil::nc( nc_inq_varid(ncid, "DZsoil", &cv) );
   temutil::nc( nc_put_vara_double(ncid, cv, start, count, &DZsoil[0]) );
@@ -1654,6 +1635,9 @@ void RestartData::write_px_front_vars(const std::string& fname, const int rowidx
 
 /** Writes arrays for variables with dimensions (Y, X, prev<XX>, pft).
 * Used for variables that need the previous 10 or 12 values.
+*
+* Note: This function name is somewhat misleading as it also handles one soil 
+* variable!
 */
 void RestartData::write_px_prev_pft_vars(const std::string& fname, const int rowidx, const int colidx) {
   int ncid;
@@ -1687,10 +1671,7 @@ void RestartData::write_px_prev_pft_vars(const std::string& fname, const int row
   temutil::nc( nc_inq_varid(ncid, "unnormleafmxA", &cv) );
   temutil::nc( nc_put_vara_double(ncid, cv, start, count, &unnormleafmxA[0][0]) );
 
-//  count[2] = 12;           // <-- previous 12 months?...
-//  temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
-//  temutil::nc( nc_put_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
-
+  // Adjust offsets for working with the a monthly soil variable.
   count[2] = 12;        // <-- previous 10 years?...
   count[3] = MAX_SOI_LAY;
 
@@ -1785,7 +1766,6 @@ void RestartData::restartdata_to_log(){
     BOOST_LOG_SEV(glg, debug) << "ICEsoil[" << ii << "]: " << ICEsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "FROZENsoil[" << ii << "]: " << FROZENsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "FROZENFRACsoil[" << ii << "]: " << FROZENFRACsoil[ii];
-//    BOOST_LOG_SEV(glg, debug) << "TEXTUREsoil[" << ii << "]: " << TEXTUREsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "rawc[" << ii << "]: " << rawc[ii];
     BOOST_LOG_SEV(glg, debug) << "soma[" << ii << "]: " << soma[ii];
     BOOST_LOG_SEV(glg, debug) << "sompr[" << ii << "]: " << sompr[ii];

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -38,11 +38,11 @@ RestartData::~RestartData() {
 
 #ifdef WITHMPI
 MPI_Datatype RestartData::register_mpi_datatype() {
-  
+
   // create types for all the dimensions in the RestartData object...
-  const int elems_in_restartdata = 65;
+  const int elems_in_restartdata = 63;
   int counts[elems_in_restartdata] = {
-    1, // int chtid;
+//    1, // int chtid;
     1, // int dsr;
     1, // double firea2sorgn;
     1, // int yrsdist;
@@ -105,7 +105,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MAX_SOI_LAY, // double ICEsoil[MAX_SOI_LAY];
     MAX_SOI_LAY, // int FROZENsoil[MAX_SOI_LAY];
     MAX_SOI_LAY, // double FROZENFRACsoil[MAX_SOI_LAY];
-    MAX_SOI_LAY, // int TEXTUREsoil[MAX_SOI_LAY];
+//    MAX_SOI_LAY, // int TEXTUREsoil[MAX_SOI_LAY];
     
     MAX_ROC_LAY, // double TSrock[MAX_ROC_LAY];
     MAX_ROC_LAY, // double DZrock[MAX_ROC_LAY];
@@ -128,7 +128,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     12 * MAX_SOI_LAY // double prvltrfcnA[12][MAX_SOI_LAY];   //previous 12-month litterfall (root death) input C/N ratios in each soil layer for adjusting 'kd'
   };
   MPI_Datatype old_types[elems_in_restartdata] = {
-    MPI_INT, // int chtid;
+//    MPI_INT, // int chtid;
     MPI_INT, // int dsr;
     MPI_DOUBLE, // double firea2sorgn;
     MPI_INT, // int yrsdist;
@@ -179,7 +179,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MPI_DOUBLE, // double ICEsoil[MAX_SOI_LAY];
     MPI_INT, // int FROZENsoil[MAX_SOI_LAY];
     MPI_DOUBLE, // double FROZENFRACsoil[MAX_SOI_LAY];
-    MPI_INT, // int TEXTUREsoil[MAX_SOI_LAY];
+//    MPI_INT, // int TEXTUREsoil[MAX_SOI_LAY];
     MPI_DOUBLE, // double TSrock[MAX_ROC_LAY];
     MPI_DOUBLE, // double DZrock[MAX_ROC_LAY];
     MPI_DOUBLE, // double frontZ[MAX_NUM_FNT];
@@ -195,7 +195,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MPI_DOUBLE // double prvltrfcnA[12][MAX_SOI_LAY];
   };
   MPI_Aint displacements[elems_in_restartdata] = {
-    offsetof(RestartData, chtid),
+//    offsetof(RestartData, chtid),
     offsetof(RestartData, dsr),
     offsetof(RestartData, firea2sorgn),
     offsetof(RestartData, yrsdist),
@@ -246,7 +246,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     offsetof(RestartData, ICEsoil),
     offsetof(RestartData, FROZENsoil),
     offsetof(RestartData, FROZENFRACsoil),
-    offsetof(RestartData, TEXTUREsoil),
+//    offsetof(RestartData, TEXTUREsoil),
     offsetof(RestartData, TSrock),
     offsetof(RestartData, DZrock),
     offsetof(RestartData, frontZ),
@@ -276,7 +276,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
 
 void RestartData::reinitValue() {
   //
-  chtid = MISSING_I;
+//  chtid = MISSING_I;
   // atm
   dsr         = MISSING_I;
   firea2sorgn = MISSING_D;
@@ -361,7 +361,7 @@ void RestartData::reinitValue() {
     ICEsoil[il]  = MISSING_D;
     FROZENsoil[il]= MISSING_I;
     FROZENFRACsoil[il]= MISSING_D;
-    TEXTUREsoil[il]   = MISSING_I;
+//    TEXTUREsoil[il]   = MISSING_I;
   }
 
   for(int il =0; il<MAX_ROC_LAY; il++) {
@@ -468,7 +468,7 @@ void RestartData::verify_logical_values(){
   //whether or not it makes sense for that value to have been initialized
   //to a low negative.
 
-  check_bounds("chtid", chtid);
+//  check_bounds("chtid", chtid);
   check_bounds("dsr", dsr);
   check_bounds("firea2sorgn", firea2sorgn);
   check_bounds("yrsdist", yrsdist);
@@ -534,7 +534,7 @@ void RestartData::verify_logical_values(){
     check_bounds("ICEsoil", ICEsoil[ii]);
     check_bounds("FROZENsoil", FROZENsoil[ii]);
     check_bounds("FROZENFRACsoil", FROZENFRACsoil[ii]);
-    check_bounds("TEXTUREsoil", TEXTUREsoil[ii]);
+//    check_bounds("TEXTUREsoil", TEXTUREsoil[ii]);
     check_bounds("rawc", rawc[ii]);
     check_bounds("soma", soma[ii]);
     check_bounds("sompr", sompr[ii]);
@@ -793,14 +793,15 @@ void RestartData::read_px_soil_vars(const std::string& fname, const int rowidx, 
   count[1] = 1;
   count[2] = MAX_SOI_LAY;
 
+
   temutil::nc( nc_inq_varid(ncid, "TYPEsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &TYPEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "AGEsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &AGEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "FROZENsoil", &cv) );
   temutil::nc( nc_get_vara_int(ncid, cv, start, count, &FROZENsoil[0]) );
-  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
-  temutil::nc( nc_get_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
+//  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
+//  temutil::nc( nc_get_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
 
   temutil::nc( nc_inq_varid(ncid, "DZsoil", &cv) );
   temutil::nc( nc_get_vara_double(ncid, cv, start, count, &DZsoil[0]) );
@@ -1125,12 +1126,12 @@ void RestartData::create_empty_file(const std::string& fname,
   vartype3D_dimids[2] = soillayerD;
 
   // Setup 3D vars, integer
-  int TEXTUREsoilV;
+//  int TEXTUREsoilV;
   int FROZENsoilV;
   int TYPEsoilV;
   int AGEsoilV;
-  temutil::nc( nc_def_var(ncid, "TEXTUREsoil", NC_INT, 3, vartype3D_dimids, &TEXTUREsoilV) );
-  temutil::nc( nc_put_att_int(ncid, TEXTUREsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
+//  temutil::nc( nc_def_var(ncid, "TEXTUREsoil", NC_INT, 3, vartype3D_dimids, &TEXTUREsoilV) );
+//  temutil::nc( nc_put_att_int(ncid, TEXTUREsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
   temutil::nc( nc_def_var(ncid, "FROZENsoil", NC_INT, 3, vartype3D_dimids, &FROZENsoilV) );
   temutil::nc( nc_put_att_int(ncid, FROZENsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
   temutil::nc( nc_def_var(ncid, "TYPEsoil", NC_INT, 3, vartype3D_dimids, &TYPEsoilV) );
@@ -1139,17 +1140,17 @@ void RestartData::create_empty_file(const std::string& fname,
   temutil::nc( nc_put_att_int(ncid, AGEsoilV, "_FillValue", NC_INT, 1, &MISSING_I) );
 
   // Setup 3D vars, double
-  int TSsoilV;
-  int DZsoilV;
-  int LIQsoilV;
-  int ICEsoilV;
-  int FROZENFRACsoilV;
-  int rawcV;
-  int somaV;
-  int somprV;
-  int somcrV;
-  int orgnV;
-  int avlnV;
+  int  TSsoilV;
+  int  DZsoilV;
+  int  LIQsoilV;
+  int  ICEsoilV;
+  int  FROZENFRACsoilV;
+  int  rawcV;
+  int  somaV;
+  int  somprV;
+  int  somcrV;
+  int  orgnV;
+  int  avlnV;
   temutil::nc( nc_def_var(ncid, "TSsoil", NC_DOUBLE, 3, vartype3D_dimids, &TSsoilV) );
   temutil::nc( nc_put_att_double(ncid, TSsoilV, "_FillValue", NC_DOUBLE, 1, &MISSING_D) );
   temutil::nc( nc_def_var(ncid, "DZsoil", NC_DOUBLE, 3, vartype3D_dimids, &DZsoilV) );
@@ -1183,6 +1184,12 @@ void RestartData::create_empty_file(const std::string& fname,
   // The old files that we've been using prior to 11/2016 seem to have been
   // using number of soil layers, so I left it at that for now....
   // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  // re-arrange dims in vartype
+  vartype3D_dimids[0] = yD;
+  vartype3D_dimids[1] = xD;
+  vartype3D_dimids[2] = snowlayerD;
+ 
   int TSsnowV;
   int DZsnowV;
   int LIQsnowV;
@@ -1261,7 +1268,7 @@ void RestartData::create_empty_file(const std::string& fname,
   vartype4D_dimids[0] = yD;
   vartype4D_dimids[1] = xD;
   vartype4D_dimids[2] = prevtwelveD;
-  vartype4D_dimids[3] = pftD;
+  vartype4D_dimids[3] = soillayerD;
 
   int prvltrfcnAV;
   temutil::nc( nc_def_var(ncid, "prvltrfcnA", NC_DOUBLE, 4, vartype4D_dimids, &prvltrfcnAV) );
@@ -1549,8 +1556,8 @@ void RestartData::write_px_soil_vars(const std::string& fname, const int rowidx,
   temutil::nc( nc_put_vara_int(ncid, cv, start, count, &AGEsoil[0]) );
   temutil::nc( nc_inq_varid(ncid, "FROZENsoil", &cv) );
   temutil::nc( nc_put_vara_int(ncid, cv, start, count, &FROZENsoil[0]) );
-  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
-  temutil::nc( nc_put_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
+//  temutil::nc( nc_inq_varid(ncid, "TEXTUREsoil", &cv) );
+//  temutil::nc( nc_put_vara_int(ncid, cv, start, count, &TEXTUREsoil[0]) );
   
   temutil::nc( nc_inq_varid(ncid, "DZsoil", &cv) );
   temutil::nc( nc_put_vara_double(ncid, cv, start, count, &DZsoil[0]) );
@@ -1778,7 +1785,7 @@ void RestartData::restartdata_to_log(){
     BOOST_LOG_SEV(glg, debug) << "ICEsoil[" << ii << "]: " << ICEsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "FROZENsoil[" << ii << "]: " << FROZENsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "FROZENFRACsoil[" << ii << "]: " << FROZENFRACsoil[ii];
-    BOOST_LOG_SEV(glg, debug) << "TEXTUREsoil[" << ii << "]: " << TEXTUREsoil[ii];
+//    BOOST_LOG_SEV(glg, debug) << "TEXTUREsoil[" << ii << "]: " << TEXTUREsoil[ii];
     BOOST_LOG_SEV(glg, debug) << "rawc[" << ii << "]: " << rawc[ii];
     BOOST_LOG_SEV(glg, debug) << "soma[" << ii << "]: " << soma[ii];
     BOOST_LOG_SEV(glg, debug) << "sompr[" << ii << "]: " << sompr[ii];

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -121,7 +121,7 @@ MPI_Datatype RestartData::register_mpi_datatype() {
     MAX_SOI_LAY, // double somcr[MAX_SOI_LAY];
     
     1, // double wdebrisn;
-    1, // double orgn[MAX_SOI_LAY];
+    MAX_SOI_LAY, // double orgn[MAX_SOI_LAY];
     
     MAX_SOI_LAY, // double avln[MAX_SOI_LAY];
     

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -915,13 +915,21 @@ void RestartData::read_px_prev_pft_vars(const std::string& fname, const int rowi
   temutil::nc( nc_inq_varid(ncid, "unnormleafmxA", &cv) );
   temutil::nc( nc_get_vara_double(ncid, cv, start, count, &unnormleafmxA[0][0]) );
 
-  count[2] = 12;           // <-- previous 12 months?...
+//  count[2] = 12;           // <-- previous 12 months?...
+//  temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
+//  temutil::nc( nc_get_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
+
+  count[2] = 12;        // <-- previous 12 months
+  count[3] = MAX_SOI_LAY;
+
   temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
   temutil::nc( nc_get_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
+
 
   temutil::nc( nc_close(ncid) );
 
 }
+
 
 /** Creates (overwrites) an empty restart file. */
 void RestartData::create_empty_file(const std::string& fname,
@@ -957,15 +965,32 @@ void RestartData::create_empty_file(const std::string& fname,
   BOOST_LOG_SEV(glg, debug) << "Creating dimensions...";
   temutil::nc( nc_def_dim(ncid, "Y", ysize, &yD) );
   temutil::nc( nc_def_dim(ncid, "X", xsize, &xD) );
-  temutil::nc( nc_def_dim(ncid, "pft", 10, &pftD) );
-  temutil::nc( nc_def_dim(ncid, "pftpart", 3, &pftpartD) );
-  temutil::nc( nc_def_dim(ncid, "snowlayer", 6, &snowlayerD) );
-  temutil::nc( nc_def_dim(ncid, "rootlayer", 10, &rootlayerD) );
-  temutil::nc( nc_def_dim(ncid, "soillayer", 23, &soillayerD) );
-  temutil::nc( nc_def_dim(ncid, "rocklayer", 5, &rocklayerD) );
+//  temutil::nc( nc_def_dim(ncid, "pft", 10, &pftD) );
+//  temutil::nc( nc_def_dim(ncid, "pftpart", 3, &pftpartD) );
+//  temutil::nc( nc_def_dim(ncid, "snowlayer", 6, &snowlayerD) );
+//  temutil::nc( nc_def_dim(ncid, "rootlayer", 10, &rootlayerD) );
+//  temutil::nc( nc_def_dim(ncid, "soillayer", 23, &soillayerD) );
+//  temutil::nc( nc_def_dim(ncid, "rocklayer", 5, &rocklayerD) );
+//  temutil::nc( nc_def_dim(ncid, "fronts", 10, &frontsD) );
+//  temutil::nc( nc_def_dim(ncid, "prevten", 10, &prevtenD) );
+//  temutil::nc( nc_def_dim(ncid, "prevtwelve", 12, &prevtwelveD) );
+
+  temutil::nc( nc_def_dim(ncid, "pft", NUM_PFT, &pftD) );
+  temutil::nc( nc_def_dim(ncid, "pftpart", NUM_PFT_PART, &pftpartD) );
+  temutil::nc( nc_def_dim(ncid, "snowlayer", MAX_SNW_LAY, &snowlayerD) );
+  temutil::nc( nc_def_dim(ncid, "rootlayer", MAX_ROT_LAY, &rootlayerD) );
+  temutil::nc( nc_def_dim(ncid, "soillayer", MAX_SOI_LAY, &soillayerD) );
+  temutil::nc( nc_def_dim(ncid, "rocklayer", MAX_ROC_LAY, &rocklayerD) );
   temutil::nc( nc_def_dim(ncid, "fronts", 10, &frontsD) );
   temutil::nc( nc_def_dim(ncid, "prevten", 10, &prevtenD) );
   temutil::nc( nc_def_dim(ncid, "prevtwelve", 12, &prevtwelveD) );
+
+//  BOOST_LOG_SEV(glg, fatal) << " NUM_PFT = " << NUM_PFT ;
+//  BOOST_LOG_SEV(glg, fatal) << " NUM_PFT_PART = " << NUM_PFT_PART ;
+//  BOOST_LOG_SEV(glg, fatal) << " MAX_ROT_LAY = " << MAX_ROT_LAY ;
+//  BOOST_LOG_SEV(glg, fatal) << " MAX_SNW_LAY = " << MAX_SNW_LAY ;
+//  BOOST_LOG_SEV(glg, fatal) << " MAX_SOI_LAY = " << MAX_SOI_LAY ;
+//  BOOST_LOG_SEV(glg, fatal) << " MAX_ROC_LAY = " << MAX_ROC_LAY ;
 
 
   // Setup arrays holding dimids for different "types" of variables

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -1166,6 +1166,9 @@ void RestartData::create_empty_file(const std::string& fname,
   // the C++ code.
   // The old files that we've been using prior to 11/2016 seem to have been
   // using number of soil layers, so I left it at that for now....
+  // NOTE: As of spring 2023 I am not sure how much of this applies. The
+  // `fix_restart` branch may have addressed this in part; not sure if it fixed
+  // the MPI type?
   // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
   // re-arrange dims in vartype

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -1680,7 +1680,13 @@ void RestartData::write_px_prev_pft_vars(const std::string& fname, const int row
   temutil::nc( nc_inq_varid(ncid, "unnormleafmxA", &cv) );
   temutil::nc( nc_put_vara_double(ncid, cv, start, count, &unnormleafmxA[0][0]) );
 
-  count[2] = 12;           // <-- previous 12 months?...
+//  count[2] = 12;           // <-- previous 12 months?...
+//  temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
+//  temutil::nc( nc_put_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
+
+  count[2] = 12;        // <-- previous 10 years?...
+  count[3] = MAX_SOI_LAY;
+
   temutil::nc( nc_inq_varid(ncid, "prvltrfcnA", &cv) );
   temutil::nc( nc_put_vara_double(ncid, cv, start, count, &prvltrfcnA[0][0]) );
 

--- a/src/RestartData.cpp
+++ b/src/RestartData.cpp
@@ -293,7 +293,7 @@ void RestartData::reinitValue() {
     lai[ip]    = MISSING_D;
 
     for (int i=0; i<MAX_ROT_LAY; i++) {
-      rootfrac[ip][i] = MISSING_D;
+      rootfrac[i][ip] = MISSING_D;
     }
 
     vegwater[ip] = MISSING_D;

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -3661,20 +3661,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       //By layer
       if(curr_spec.layer){
 
-        double orgn[MAX_SOI_LAY] = {0};
-        int il = 0;
-        Layer* currL = this->cohort.ground.toplayer;
-        while(currL != NULL){
-          orgn[il] = currL->orgn;
-          il++;
-          currL = currL->nextl;
-        }
+//        double orgn[MAX_SOI_LAY] = {0};
+//        int il = 0;
+//        Layer* currL = this->cohort.ground.toplayer;
+//        while(currL != NULL){
+//          orgn[il] = currL->orgn;
+//          il++;
+//          currL = currL->nextl;
+//        }
 
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, month_timestep, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, year, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, year, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
         }
 
       }
@@ -4418,20 +4420,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       //By layer
       if(curr_spec.layer){
 
-        double soilc[MAX_SOI_LAY];
-        int il = 0;
-        Layer* currL = this->cohort.ground.toplayer;
-        while(currL != NULL){
-          soilc[il] = currL->soma;
-          il++;
-          currL = currL->nextl;
-        }
+//        double soilc[MAX_SOI_LAY];
+//        int il = 0;
+//        Layer* currL = this->cohort.ground.toplayer;
+//        while(currL != NULL){
+//          soilc[il] = currL->soma;
+//          il++;
+//          currL = currL->nextl;
+//        }
 
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
       //Total, instead of by layer
@@ -4462,20 +4466,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       //By layer
       if(curr_spec.layer){
 
-        double soilc[MAX_SOI_LAY];
-        int il = 0;
-        Layer* currL = this->cohort.ground.toplayer;
-        while(currL != NULL){
-          soilc[il] = currL->somcr;
-          il++;
-          currL = currL->nextl;
-        }
+//        double soilc[MAX_SOI_LAY];
+//        int il = 0;
+//        Layer* currL = this->cohort.ground.toplayer;
+//        while(currL != NULL){
+//          soilc[il] = currL->somcr;
+//          il++;
+//          currL = currL->nextl;
+//        }
 
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
       //Total, instead of by layer
@@ -4506,20 +4512,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       //By layer
       if(curr_spec.layer){
 
-        double soilc[MAX_SOI_LAY];
-        int il = 0;
-        Layer* currL = this->cohort.ground.toplayer;
-        while(currL != NULL){
-          soilc[il] = currL->sompr;
-          il++;
-          currL = currL->nextl;
-        }
+//        double soilc[MAX_SOI_LAY];
+//        int il = 0;
+//        Layer* currL = this->cohort.ground.toplayer;
+//        while(currL != NULL){
+//          soilc[il] = currL->sompr;
+//          il++;
+//          currL = currL->nextl;
+//        }
 
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+ //         output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
       //Total, instead of by layer
@@ -4550,20 +4558,22 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
       //By layer
       if(curr_spec.layer){
 
-        double soilc[MAX_SOI_LAY];
-        int il = 0;
-        Layer* currL = this->cohort.ground.toplayer;
-        while(currL != NULL){
-          soilc[il] = currL->rawc;
-          il++;
-          currL = currL->nextl;
-        }
+  //      double soilc[MAX_SOI_LAY];
+  //      int il = 0;
+  //      Layer* currL = this->cohort.ground.toplayer;
+  //      while(currL != NULL){
+  //        soilc[il] = currL->rawc;
+  //        il++;
+  //        currL = currL->nextl;
+  //      }
 
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.rawc[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.rawc[0], MAX_SOI_LAY, year, 1);
         }
       }
       //Total, instead of by layer

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -4444,7 +4444,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.somcr[0], MAX_SOI_LAY, year, 1);
         }
       }
       //Total, instead of by layer
@@ -4478,7 +4478,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.sompr[0], MAX_SOI_LAY, year, 1);
         }
       }
       //Total, instead of by layer

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -3660,25 +3660,12 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
-
-//        double orgn[MAX_SOI_LAY] = {0};
-//        int il = 0;
-//        Layer* currL = this->cohort.ground.toplayer;
-//        while(currL != NULL){
-//          orgn[il] = currL->orgn;
-//          il++;
-//          currL = currL->nextl;
-//        }
-
         if(curr_spec.monthly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, month_timestep, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &orgn[0], MAX_SOI_LAY, year, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
         }
-
       }
       //Total, instead of by layer
       else if(!curr_spec.layer){
@@ -4419,22 +4406,10 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
-
-//        double soilc[MAX_SOI_LAY];
-//        int il = 0;
-//        Layer* currL = this->cohort.ground.toplayer;
-//        while(currL != NULL){
-//          soilc[il] = currL->soma;
-//          il++;
-//          currL = currL->nextl;
-//        }
-
         if(curr_spec.monthly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
@@ -4465,22 +4440,10 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
-
-//        double soilc[MAX_SOI_LAY];
-//        int il = 0;
-//        Layer* currL = this->cohort.ground.toplayer;
-//        while(currL != NULL){
-//          soilc[il] = currL->somcr;
-//          il++;
-//          currL = currL->nextl;
-//        }
-
         if(curr_spec.monthly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.somcr[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
@@ -4511,22 +4474,10 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
-
-//        double soilc[MAX_SOI_LAY];
-//        int il = 0;
-//        Layer* currL = this->cohort.ground.toplayer;
-//        while(currL != NULL){
-//          soilc[il] = currL->sompr;
-//          il++;
-//          currL = currL->nextl;
-//        }
-
         if(curr_spec.monthly){
- //         output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.sompr[0], MAX_SOI_LAY, month_timestep, 1);
         }
       }
@@ -4557,22 +4508,10 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
-
-  //      double soilc[MAX_SOI_LAY];
-  //      int il = 0;
-  //      Layer* currL = this->cohort.ground.toplayer;
-  //      while(currL != NULL){
-  //        soilc[il] = currL->rawc;
-  //        il++;
-  //        currL = currL->nextl;
-  //      }
-
         if(curr_spec.monthly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, month_timestep, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.rawc[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-//          output_nc_4dim(&curr_spec, file_stage_suffix, &soilc[0], MAX_SOI_LAY, year, 1);
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.rawc[0], MAX_SOI_LAY, year, 1);
         }
       }

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -3664,7 +3664,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.orgn[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.orgn[0], MAX_SOI_LAY, year, 1);
         }
       }
       //Total, instead of by layer
@@ -4410,7 +4410,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
           output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
         }
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.soma[0], MAX_SOI_LAY, month_timestep, 1);
+          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.soma[0], MAX_SOI_LAY, year, 1);
         }
       }
       //Total, instead of by layer

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -125,6 +125,7 @@ void Vegetation::initializeState() {
   //
   for (int i=0; i<NUM_PFT; i++) {
     cd->m_veg.vegage[i]  = 0;
+//    BOOST_LOG_SEV(glg, err) << "initialization!";
   }
 
   // from 'lookup'
@@ -162,10 +163,12 @@ void Vegetation::initializeState() {
 
 //set the initial states from restart inputs:
 void Vegetation::set_state_from_restartdata(const RestartData & rd) {
+
   cd->yrsdist = rd.yrsdist;
 
   for (int ip=0; ip<NUM_PFT; ip++) {
     cd->m_veg.vegage[ip]      = rd.vegage[ip];
+//    BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd->m_veg.vegage[ip];
     cd->m_veg.vegcov[ip]      = rd.vegcov[ip];
     cd->m_veg.ifwoody[ip]     = rd.ifwoody[ip];
     cd->m_veg.ifdeciwoody[ip] = rd.ifdeciwoody[ip];
@@ -183,6 +186,7 @@ void Vegetation::set_state_from_restartdata(const RestartData & rd) {
     cd->m_vegd.growingttime[ip] = rd.growingttime[ip];
     cd->m_vegd.topt[ip]         = rd.topt[ip];
     cd->m_vegd.foliagemx[ip]    = rd.foliagemx[ip];
+//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << ", foliagemx: " << cd->m_vegd.foliagemx[ip];
     cd->prveetmxque[ip].clear();
 
     for(int i=0; i<10; i++) {
@@ -341,7 +345,6 @@ void Vegetation::phenology(const int &currmind) {
                                             bd[ip]->m_vegs.call);
 
       // 2) current EET and previous max. EET controlled
-      // 1) current EET and previous max. EET controlled
       double tempunnormleaf = 0.;;
       double eet = ed[ip]->m_v2a.tran;//originally it's using 'l2a.eet', which
                                       //  includes soil/veg evaporation - that
@@ -366,6 +369,8 @@ void Vegetation::phenology(const int &currmind) {
         cd->m_vegd.topt[ip] = ed[ip]->m_atms.ta;
         cd->m_vegd.maxleafc[ip] = 0.0;
         cd->m_vegd.maxleafc[ip] = getYearlyMaxLAI(ip)/vegdimpar.sla[ip];
+//        BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
+//           " - vegcov : " << cd->m_veg.vegcov[ip] << " - sla : " << vegdimpar.sla[ip] << " - maxlai: " << getYearlyMaxLAI(ip) ;
       } else {
         if (eet>cd->m_vegd.eetmx[ip]) {
           cd->m_vegd.eetmx[ip] = eet;
@@ -410,6 +415,12 @@ void Vegetation::phenology(const int &currmind) {
       cd->m_vegd.growingttime[ip] = MISSING_D;
       cd->m_vegd.ffoliage[ip] = MISSING_D;
     }
+//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
+//           " - vegcov : " << cd->m_veg.vegcov[ip] << " - sla : " << vegdimpar.sla[ip] << " - maxlai: " << getYearlyMaxLAI(ip) ;
+//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
+//           " - unnormleaf : " << cd->m_vegd.unnormleaf[ip] << " - fleaf : " << cd->m_vegd.fleaf[ip] << " - eetmx: " << cd->m_vegd.eetmx[ip] 
+//           << " - unnormleafmx: " << cd->m_vegd.unnormleafmx[ip]  << " - topt: " << cd->m_vegd.topt[ip] << " - growingttime: " << cd->m_vegd.growingttime[ip] 
+//           << " - ffoliage: " <<  cd->m_vegd.ffoliage[ip];
   }
 };
 
@@ -487,12 +498,23 @@ double Vegetation::getFfoliage(const int &ipft, const bool & ifwoody,
   //    ffoliage =  1./(1+m1*exp(m2*sqrt(fcv)));
   //  }
 
+  //BOOST_LOG_SEV(glg, err) << "Before update - pft: " << ipft << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
+  //           << ", ffoliage: " << ffoliage << ", topt" << cd->m_vegd.topt[ipft];
+
   //it is assumed that foliage will not go down during a growth cycle
   if(ffoliage>cd->m_vegd.foliagemx[ipft]) {
     cd->m_vegd.foliagemx[ipft] = ffoliage;
   } else {
     ffoliage = cd->m_vegd.foliagemx[ipft];
   }
+
+//  BOOST_LOG_SEV(glg, err) << "After update - pft: " << ipft << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
+//             << ", ffoliage: " << ffoliage;
+//  BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", kfoliage: " << vegdimpar.kfoliage[ipft] << ", cov: " 
+//             << vegdimpar.cov[ipft] << ", vegc: " << vegc << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
+//             << ", ffoliage: " << ffoliage;
+
+
 
   return ffoliage;
 };
@@ -508,10 +530,14 @@ double Vegetation::getYearlyMaxLAI(const int &ipft) {
       double covlai = chtlu->static_lai[im][ipft];
     if (laimax <= covlai) {
       laimax = covlai;
+//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - month: " << im <<
+//           " - staticlai : " << chtlu->static_lai[im][ipft];
     }
   }
 
   laimax *= cd->m_vegd.ffoliage[ipft];
+//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - laimax: " << laimax <<
+//           " - ffoliage : " << cd->m_vegd.ffoliage[ipft];
   return laimax;
 }
 

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -334,6 +334,13 @@ void Vegetation::phenology(const int &currmind) {
         prveetmx +=prvdeque[i]/dequeno;
       }
 
+      //1) plant size (biomass C) or age controlled foliage fraction rative
+      //   to the max. leaf C
+      cd->m_vegd.ffoliage[ip] = getFfoliage(ip, cd->m_veg.ifwoody[ip],
+                                            cd->m_veg.ifperenial[ip],
+                                            bd[ip]->m_vegs.call);
+
+      // 2) current EET and previous max. EET controlled
       // 1) current EET and previous max. EET controlled
       double tempunnormleaf = 0.;;
       double eet = ed[ip]->m_v2a.tran;//originally it's using 'l2a.eet', which
@@ -357,6 +364,7 @@ void Vegetation::phenology(const int &currmind) {
         cd->m_vegd.unnormleafmx[ip] = tempunnormleaf;
         cd->m_vegd.growingttime[ip] = ed[ip]->m_soid.rtdpgdd;
         cd->m_vegd.topt[ip] = ed[ip]->m_atms.ta;
+        cd->m_vegd.maxleafc[ip] = 0.0;
         cd->m_vegd.maxleafc[ip] = getYearlyMaxLAI(ip)/vegdimpar.sla[ip];
       } else {
         if (eet>cd->m_vegd.eetmx[ip]) {

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -162,6 +162,8 @@ void Vegetation::initializeState() {
 
 //set the initial states from restart inputs:
 void Vegetation::set_state_from_restartdata(const RestartData & rd) {
+  cd->yrsdist = rd.yrsdist;
+
   for (int ip=0; ip<NUM_PFT; ip++) {
     cd->m_veg.vegage[ip]      = rd.vegage[ip];
     cd->m_veg.vegcov[ip]      = rd.vegcov[ip];

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -125,7 +125,6 @@ void Vegetation::initializeState() {
   //
   for (int i=0; i<NUM_PFT; i++) {
     cd->m_veg.vegage[i]  = 0;
-//    BOOST_LOG_SEV(glg, err) << "initialization!";
   }
 
   // from 'lookup'
@@ -168,7 +167,6 @@ void Vegetation::set_state_from_restartdata(const RestartData & rd) {
 
   for (int ip=0; ip<NUM_PFT; ip++) {
     cd->m_veg.vegage[ip]      = rd.vegage[ip];
-//    BOOST_LOG_SEV(glg, err) << "pft: " << ip << ", vegage: " << cd->m_veg.vegage[ip];
     cd->m_veg.vegcov[ip]      = rd.vegcov[ip];
     cd->m_veg.ifwoody[ip]     = rd.ifwoody[ip];
     cd->m_veg.ifdeciwoody[ip] = rd.ifdeciwoody[ip];
@@ -186,7 +184,6 @@ void Vegetation::set_state_from_restartdata(const RestartData & rd) {
     cd->m_vegd.growingttime[ip] = rd.growingttime[ip];
     cd->m_vegd.topt[ip]         = rd.topt[ip];
     cd->m_vegd.foliagemx[ip]    = rd.foliagemx[ip];
-//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << ", foliagemx: " << cd->m_vegd.foliagemx[ip];
     cd->prveetmxque[ip].clear();
 
     for(int i=0; i<10; i++) {
@@ -338,8 +335,8 @@ void Vegetation::phenology(const int &currmind) {
         prveetmx +=prvdeque[i]/dequeno;
       }
 
-      //1) plant size (biomass C) or age controlled foliage fraction rative
-      //   to the max. leaf C
+      // 1) plant size (biomass C) or age controlled foliage fraction relative
+      //    to the max. leaf C
       cd->m_vegd.ffoliage[ip] = getFfoliage(ip, cd->m_veg.ifwoody[ip],
                                             cd->m_veg.ifperenial[ip],
                                             bd[ip]->m_vegs.call);
@@ -369,8 +366,6 @@ void Vegetation::phenology(const int &currmind) {
         cd->m_vegd.topt[ip] = ed[ip]->m_atms.ta;
         cd->m_vegd.maxleafc[ip] = 0.0;
         cd->m_vegd.maxleafc[ip] = getYearlyMaxLAI(ip)/vegdimpar.sla[ip];
-//        BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
-//           " - vegcov : " << cd->m_veg.vegcov[ip] << " - sla : " << vegdimpar.sla[ip] << " - maxlai: " << getYearlyMaxLAI(ip) ;
       } else {
         if (eet>cd->m_vegd.eetmx[ip]) {
           cd->m_vegd.eetmx[ip] = eet;
@@ -400,11 +395,6 @@ void Vegetation::phenology(const int &currmind) {
         }
       }
 
-//      //2) plant size (biomass C) or age controlled foliage fraction rative
-//      //   to the max. leaf C
-//      cd->m_vegd.ffoliage[ip] = getFfoliage(ip, cd->m_veg.ifwoody[ip],
-//                                            cd->m_veg.ifperenial[ip],
-//                                            bd[ip]->m_vegs.call);
     } else { // 'vegcov' is 0
       cd->m_vegd.unnormleaf[ip] = MISSING_D;
       cd->m_vegd.fleaf[ip] = MISSING_D;
@@ -415,12 +405,6 @@ void Vegetation::phenology(const int &currmind) {
       cd->m_vegd.growingttime[ip] = MISSING_D;
       cd->m_vegd.ffoliage[ip] = MISSING_D;
     }
-//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
-//           " - vegcov : " << cd->m_veg.vegcov[ip] << " - sla : " << vegdimpar.sla[ip] << " - maxlai: " << getYearlyMaxLAI(ip) ;
-//    BOOST_LOG_SEV(glg, err) << "PFT :" << ip << " - maxleafc: " << cd->m_vegd.maxleafc[ip] <<
-//           " - unnormleaf : " << cd->m_vegd.unnormleaf[ip] << " - fleaf : " << cd->m_vegd.fleaf[ip] << " - eetmx: " << cd->m_vegd.eetmx[ip] 
-//           << " - unnormleafmx: " << cd->m_vegd.unnormleafmx[ip]  << " - topt: " << cd->m_vegd.topt[ip] << " - growingttime: " << cd->m_vegd.growingttime[ip] 
-//           << " - ffoliage: " <<  cd->m_vegd.ffoliage[ip];
   }
 };
 
@@ -498,23 +482,12 @@ double Vegetation::getFfoliage(const int &ipft, const bool & ifwoody,
   //    ffoliage =  1./(1+m1*exp(m2*sqrt(fcv)));
   //  }
 
-  //BOOST_LOG_SEV(glg, err) << "Before update - pft: " << ipft << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
-  //           << ", ffoliage: " << ffoliage << ", topt" << cd->m_vegd.topt[ipft];
-
   //it is assumed that foliage will not go down during a growth cycle
   if(ffoliage>cd->m_vegd.foliagemx[ipft]) {
     cd->m_vegd.foliagemx[ipft] = ffoliage;
   } else {
     ffoliage = cd->m_vegd.foliagemx[ipft];
   }
-
-//  BOOST_LOG_SEV(glg, err) << "After update - pft: " << ipft << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
-//             << ", ffoliage: " << ffoliage;
-//  BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", kfoliage: " << vegdimpar.kfoliage[ipft] << ", cov: " 
-//             << vegdimpar.cov[ipft] << ", vegc: " << vegc << ", foliagemx: " << cd->m_vegd.foliagemx[ipft] 
-//             << ", ffoliage: " << ffoliage;
-
-
 
   return ffoliage;
 };
@@ -530,14 +503,10 @@ double Vegetation::getYearlyMaxLAI(const int &ipft) {
       double covlai = chtlu->static_lai[im][ipft];
     if (laimax <= covlai) {
       laimax = covlai;
-//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - month: " << im <<
-//           " - staticlai : " << chtlu->static_lai[im][ipft];
     }
   }
 
   laimax *= cd->m_vegd.ffoliage[ipft];
-//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - laimax: " << laimax <<
-//           " - ffoliage : " << cd->m_vegd.ffoliage[ipft];
   return laimax;
 }
 

--- a/src/Vegetation.cpp
+++ b/src/Vegetation.cpp
@@ -395,11 +395,11 @@ void Vegetation::phenology(const int &currmind) {
         }
       }
 
-      //2) plant size (biomass C) or age controlled foliage fraction rative
-      //   to the max. leaf C
-      cd->m_vegd.ffoliage[ip] = getFfoliage(ip, cd->m_veg.ifwoody[ip],
-                                            cd->m_veg.ifperenial[ip],
-                                            bd[ip]->m_vegs.call);
+//      //2) plant size (biomass C) or age controlled foliage fraction rative
+//      //   to the max. leaf C
+//      cd->m_vegd.ffoliage[ip] = getFfoliage(ip, cd->m_veg.ifwoody[ip],
+//                                            cd->m_veg.ifperenial[ip],
+//                                            bd[ip]->m_vegs.call);
     } else { // 'vegcov' is 0
       cd->m_vegd.unnormleaf[ip] = MISSING_D;
       cd->m_vegd.fleaf[ip] = MISSING_D;

--- a/src/Vegetation_Bgc.cpp
+++ b/src/Vegetation_Bgc.cpp
@@ -118,7 +118,6 @@ void Vegetation_Bgc::initializeState() {
 
   for (int i=0; i<NUM_PFT_PART; i++) {
     bd->m_vegs.c[i]    = chtlu->initvegc[i][ipft];
- //   BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part: " << i << " - vegc : " << bd->m_vegs.c[i];
     // Save five percent of structural nitrogen for labile. See below.
     bd->m_vegs.strn[i] = chtlu->initvegn[i][ipft]*0.95;
     totvegn += chtlu->initvegn[i][ipft];
@@ -148,7 +147,6 @@ void Vegetation_Bgc::initializeState() {
 void Vegetation_Bgc::set_state_from_restartdata(const RestartData & rdata) {
   for (int i=0; i<NUM_PFT_PART; i++) {
     bd->m_vegs.c[i]    = rdata.vegc[i][ipft];
-//    BOOST_LOG_SEV(glg, err) << "restart - PFT :" << ipft << " - part: " << i << " - vegc : " << bd->m_vegs.c[i];
     bd->m_vegs.strn[i] = rdata.strn[i][ipft];
     bgcpar.c2neven[i] = rdata.vegC2N[i][ipft];
   }
@@ -235,9 +233,6 @@ void Vegetation_Bgc::prepareIntegration(const bool &nfeedback) {
   dleafc -= bd->m_vegs.c[I_leaf];
   dleafc = fmax(0.0, dleafc);
   // litter-falling seasonal adjustment
-
-//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - maxleafc: " << cd->m_vegd.maxleafc[ipft] <<
-//           " - fleaf : " << cd->m_vegd.fleaf[ipft] << " - leafc : " << bd->m_vegs.c[I_leaf] << " - dleafc: " << dleafc ;
 
   //previous 10 year mean of growing season degree-day, using for
   //  normalizing current growing period needed for litterfalling
@@ -392,15 +387,12 @@ void Vegetation_Bgc::delta() {
     } else {
       del_v2a.rm[i] = 0.0;
     }
-//    BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i << " - rm: " << del_v2a.rm[i] << " - kr: " << bd->m_vegd.kr[i] << " - vegc: " << tmp_vegs.c[i];
     rm_wholePFT += del_v2a.rm[i];
   }
 
   // C available from GPP for allocation to new tissue after
   // accounting for maintenance respiration.
   double C_avail = gpp_all - rm_wholePFT;
-//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - C_avail:" << C_avail <<" - gpp_all: " << gpp_all 
-//        << " - rm_wholePFT : " << rm_wholePFT;
 
   // For instances when Rm is larger than GPP, i.e. winter months
   if (rm_wholePFT > gpp_all) {
@@ -418,7 +410,6 @@ void Vegetation_Bgc::delta() {
     // We decided to first affect the stem and root compartment because they
     // are considered as "storage compartment", and then leaves (for evergreens)
     for (int i=I_leaf; i<NUM_PFT_PART; i++) {
-//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i <<" - vegc: " << tmp_vegs.c[i];
       if (tmp_vegs.c[i] > 0.0) {
         del_a2v.innpp[i] = (gpp_all * bgcpar.cpart[i] / cpart_all) - del_v2a.rm[i];
         if (del_a2v.innpp[i] > 0.0) {
@@ -484,12 +475,6 @@ void Vegetation_Bgc::delta() {
   // Partition 'ingpp' based on initial NPP, Rg, and Rm
   for (int i=0; i<NUM_PFT_PART; i++) {
     del_a2v.ingpp[i] = del_a2v.innpp[i] + del_v2a.rm[i] + del_v2a.rg[i];
-//    BOOST_LOG_SEV(glg, err) << "delta - PFT :" << ipft << " - part: " << i << " - ingpp: " << del_a2v.ingpp[i] << 
-//    " - innpp: " << del_a2v.innpp[i] << " - rm: " << del_v2a.rm[i] << " - rg: " << del_v2a.rg[i];
-//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i << " - vegc: " << tmp_vegs.c[i] <<
-//           " - cpart : " << bgcpar.cpart[i] << " - cpart_all : " << cpart_all << " - rm : " << del_v2a.rm[i] << 
-//           " - frg : " << calpar.frg << " - dleafc: " << dleafc << " - rm_wholePFT: " << rm_wholePFT << " - gpp_all: " << gpp_all;
-
   }
 
   // Handle litterfall
@@ -499,11 +484,6 @@ void Vegetation_Bgc::delta() {
     } else {
       del_v2soi.ltrfalc[i] = 0.0;
     }
-//    BOOST_LOG_SEV(glg, err) << "vegc, PFT :" << ipft << " - part: " << i << " - vegc : " << tmp_vegs.c[i];
-//    BOOST_LOG_SEV(glg, err) << "cfall, PFT :" << ipft << " - part: " << i << " - vegc : " << calpar.cfall[i];
-//    BOOST_LOG_SEV(glg, err) << "delta - PFT :" << ipft << " - part: " << i << " - vegc: " << tmp_vegs.c[i] << 
-//    " - ltrfalc: " << del_v2soi.ltrfalc[i] << " - ingpp: " << del_a2v.ingpp[i] << " - innpp: " << del_a2v.innpp[i] << 
-//    " - rm: " << del_v2a.rm[i] << " - rg: " << del_v2a.rg[i];
   }
 }
 
@@ -543,8 +523,6 @@ void Vegetation_Bgc::deltanfeed() {
       double avln = 0.0;
       for(int il=0; il<cd->m_soil.numsl; il++) {
         if (cd->m_soil.frootfrac[il][ipft] > 0.0) {
-//          BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", part: " << il << ", frootfrac: " 
-//              << cd->m_soil.frootfrac[il][ipft] << ", avln: " << bd->m_sois.avln[il];
           avln += bd->m_sois.avln[il];
         }
       }
@@ -556,9 +534,6 @@ void Vegetation_Bgc::deltanfeed() {
       // For non-vascular plants innuptake is not influenced by soil
       // available Nitrogen! Nothing to do...
     }
-
-//    BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", ffoliage: " << cd->m_vegd.ffoliage[ipft] << ", q10: " 
-//              << bd->m_vegd.raq10 << ", kuptake: " << bgcpar.knuptake << ", nmax: " << calpar.nmax ;
 
 
     // N litterfall and accompanying resorbtion
@@ -755,17 +730,8 @@ void Vegetation_Bgc::deltanfeed() {
       del_soi2v.lnuptake = 0.0;
     }
 
-//    for (int i=0; i<NUM_PFT_PART; i++) {
-//      BOOST_LOG_SEV(glg, err) << "deltanfeed - PFT :" << ipft << " - part: " << i << " - vegc: " << tmp_vegs.c[i] << 
-//      " - snuptake: " << del_soi2v.snuptake[i] << " - nmobil: " << del_v2v.nmobil[i] << " - ltrfaln: " << del_v2soi.ltrfaln[i] << 
-//      " - rm: " << del_v2a.rm[i] << " - require: " << tmp_vegs.nreq[i] << " - nresorb: " << del_v2v.nresorb[i] << " - gpp: " << 
-//      del_a2v.gpp[i] << " - npp: " << del_a2v.gpp[i] << " - rg: " << del_v2a.rg[i];
-//    }
-//    BOOST_LOG_SEV(glg, err) << "deltanfeed - PFT :" << ipft << " - innuptake: " << del_soi2v.innuptake;
-
     // end of nfeed
   } else {
-//    BOOST_LOG_SEV(glg, err) << "nfeed off"; 
     for (int i=0; i<NUM_PFT_PART; i++) {
       del_a2v.gpp[i] = del_a2v.ingpp[i];
       del_a2v.npp[i] = del_a2v.innpp[i];
@@ -793,13 +759,6 @@ void Vegetation_Bgc::deltastate() {
       del_vegs.labn += del_v2v.nresorb[i] - del_v2v.nmobil[i];
     }
   }
-
-//  for (int i=0; i<NUM_PFT_PART; i++) {
-//    BOOST_LOG_SEV(glg, err) << "deltastate - PFT :" << ipft << " - part: " << i << " - vegc: " << del_vegs.c[i] << 
-//    " - npp: " << del_a2v.npp[i] << " - ltrfal: " << del_v2soi.ltrfalc[i] << " - strn: " << del_vegs.strn[i] << 
-//    " - snuptake: " << del_soi2v.snuptake[i] << " - nmobil: " << del_v2v.nmobil[i] << " - nresorb: " << del_v2v.nresorb[i] << " - ltrfaln: " << del_v2soi.ltrfaln[i];
-//  }
-
 };
 
 // summarize some variables not done in 'integrator'
@@ -905,10 +864,6 @@ double  Vegetation_Bgc::getGPP(const double &co2, const double &par,
   gpp *= fpar;
   gpp *= ftemp;
   gpp *= thawpcnt;
-
-// BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", cmax: " << calpar.cmax << ", foliage: " 
-//              << foliage << ", ci: " << ci << ", fpar: " << fpar << ", ftemp: " 
-//              << ftemp << ", thawpcnt: " << thawpcnt;
 
   if(gpp < 0.0) {
     gpp = 0.0;

--- a/src/Vegetation_Bgc.cpp
+++ b/src/Vegetation_Bgc.cpp
@@ -118,6 +118,7 @@ void Vegetation_Bgc::initializeState() {
 
   for (int i=0; i<NUM_PFT_PART; i++) {
     bd->m_vegs.c[i]    = chtlu->initvegc[i][ipft];
+ //   BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part: " << i << " - vegc : " << bd->m_vegs.c[i];
     // Save five percent of structural nitrogen for labile. See below.
     bd->m_vegs.strn[i] = chtlu->initvegn[i][ipft]*0.95;
     totvegn += chtlu->initvegn[i][ipft];
@@ -147,6 +148,7 @@ void Vegetation_Bgc::initializeState() {
 void Vegetation_Bgc::set_state_from_restartdata(const RestartData & rdata) {
   for (int i=0; i<NUM_PFT_PART; i++) {
     bd->m_vegs.c[i]    = rdata.vegc[i][ipft];
+//    BOOST_LOG_SEV(glg, err) << "restart - PFT :" << ipft << " - part: " << i << " - vegc : " << bd->m_vegs.c[i];
     bd->m_vegs.strn[i] = rdata.strn[i][ipft];
     bgcpar.c2neven[i] = rdata.vegC2N[i][ipft];
   }
@@ -233,6 +235,9 @@ void Vegetation_Bgc::prepareIntegration(const bool &nfeedback) {
   dleafc -= bd->m_vegs.c[I_leaf];
   dleafc = fmax(0.0, dleafc);
   // litter-falling seasonal adjustment
+
+//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - maxleafc: " << cd->m_vegd.maxleafc[ipft] <<
+//           " - fleaf : " << cd->m_vegd.fleaf[ipft] << " - leafc : " << bd->m_vegs.c[I_leaf] << " - dleafc: " << dleafc ;
 
   //previous 10 year mean of growing season degree-day, using for
   //  normalizing current growing period needed for litterfalling
@@ -387,12 +392,15 @@ void Vegetation_Bgc::delta() {
     } else {
       del_v2a.rm[i] = 0.0;
     }
+//    BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i << " - rm: " << del_v2a.rm[i] << " - kr: " << bd->m_vegd.kr[i] << " - vegc: " << tmp_vegs.c[i];
     rm_wholePFT += del_v2a.rm[i];
   }
 
   // C available from GPP for allocation to new tissue after
   // accounting for maintenance respiration.
   double C_avail = gpp_all - rm_wholePFT;
+//  BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - C_avail:" << C_avail <<" - gpp_all: " << gpp_all 
+//        << " - rm_wholePFT : " << rm_wholePFT;
 
   // For instances when Rm is larger than GPP, i.e. winter months
   if (rm_wholePFT > gpp_all) {
@@ -410,6 +418,7 @@ void Vegetation_Bgc::delta() {
     // We decided to first affect the stem and root compartment because they
     // are considered as "storage compartment", and then leaves (for evergreens)
     for (int i=I_leaf; i<NUM_PFT_PART; i++) {
+//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i <<" - vegc: " << tmp_vegs.c[i];
       if (tmp_vegs.c[i] > 0.0) {
         del_a2v.innpp[i] = (gpp_all * bgcpar.cpart[i] / cpart_all) - del_v2a.rm[i];
         if (del_a2v.innpp[i] > 0.0) {
@@ -471,9 +480,16 @@ void Vegetation_Bgc::delta() {
     innpp_all += del_a2v.innpp[i];
   }
 
+
   // Partition 'ingpp' based on initial NPP, Rg, and Rm
   for (int i=0; i<NUM_PFT_PART; i++) {
     del_a2v.ingpp[i] = del_a2v.innpp[i] + del_v2a.rm[i] + del_v2a.rg[i];
+//    BOOST_LOG_SEV(glg, err) << "delta - PFT :" << ipft << " - part: " << i << " - ingpp: " << del_a2v.ingpp[i] << 
+//    " - innpp: " << del_a2v.innpp[i] << " - rm: " << del_v2a.rm[i] << " - rg: " << del_v2a.rg[i];
+//      BOOST_LOG_SEV(glg, err) << "PFT :" << ipft << " - part:" << i << " - vegc: " << tmp_vegs.c[i] <<
+//           " - cpart : " << bgcpar.cpart[i] << " - cpart_all : " << cpart_all << " - rm : " << del_v2a.rm[i] << 
+//           " - frg : " << calpar.frg << " - dleafc: " << dleafc << " - rm_wholePFT: " << rm_wholePFT << " - gpp_all: " << gpp_all;
+
   }
 
   // Handle litterfall
@@ -483,6 +499,11 @@ void Vegetation_Bgc::delta() {
     } else {
       del_v2soi.ltrfalc[i] = 0.0;
     }
+//    BOOST_LOG_SEV(glg, err) << "vegc, PFT :" << ipft << " - part: " << i << " - vegc : " << tmp_vegs.c[i];
+//    BOOST_LOG_SEV(glg, err) << "cfall, PFT :" << ipft << " - part: " << i << " - vegc : " << calpar.cfall[i];
+//    BOOST_LOG_SEV(glg, err) << "delta - PFT :" << ipft << " - part: " << i << " - vegc: " << tmp_vegs.c[i] << 
+//    " - ltrfalc: " << del_v2soi.ltrfalc[i] << " - ingpp: " << del_a2v.ingpp[i] << " - innpp: " << del_a2v.innpp[i] << 
+//    " - rm: " << del_v2a.rm[i] << " - rg: " << del_v2a.rg[i];
   }
 }
 
@@ -522,6 +543,8 @@ void Vegetation_Bgc::deltanfeed() {
       double avln = 0.0;
       for(int il=0; il<cd->m_soil.numsl; il++) {
         if (cd->m_soil.frootfrac[il][ipft] > 0.0) {
+//          BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", part: " << il << ", frootfrac: " 
+//              << cd->m_soil.frootfrac[il][ipft] << ", avln: " << bd->m_sois.avln[il];
           avln += bd->m_sois.avln[il];
         }
       }
@@ -533,6 +556,9 @@ void Vegetation_Bgc::deltanfeed() {
       // For non-vascular plants innuptake is not influenced by soil
       // available Nitrogen! Nothing to do...
     }
+
+//    BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", ffoliage: " << cd->m_vegd.ffoliage[ipft] << ", q10: " 
+//              << bd->m_vegd.raq10 << ", kuptake: " << bgcpar.knuptake << ", nmax: " << calpar.nmax ;
 
 
     // N litterfall and accompanying resorbtion
@@ -729,8 +755,17 @@ void Vegetation_Bgc::deltanfeed() {
       del_soi2v.lnuptake = 0.0;
     }
 
+//    for (int i=0; i<NUM_PFT_PART; i++) {
+//      BOOST_LOG_SEV(glg, err) << "deltanfeed - PFT :" << ipft << " - part: " << i << " - vegc: " << tmp_vegs.c[i] << 
+//      " - snuptake: " << del_soi2v.snuptake[i] << " - nmobil: " << del_v2v.nmobil[i] << " - ltrfaln: " << del_v2soi.ltrfaln[i] << 
+//      " - rm: " << del_v2a.rm[i] << " - require: " << tmp_vegs.nreq[i] << " - nresorb: " << del_v2v.nresorb[i] << " - gpp: " << 
+//      del_a2v.gpp[i] << " - npp: " << del_a2v.gpp[i] << " - rg: " << del_v2a.rg[i];
+//    }
+//    BOOST_LOG_SEV(glg, err) << "deltanfeed - PFT :" << ipft << " - innuptake: " << del_soi2v.innuptake;
+
     // end of nfeed
   } else {
+//    BOOST_LOG_SEV(glg, err) << "nfeed off"; 
     for (int i=0; i<NUM_PFT_PART; i++) {
       del_a2v.gpp[i] = del_a2v.ingpp[i];
       del_a2v.npp[i] = del_a2v.innpp[i];
@@ -758,6 +793,13 @@ void Vegetation_Bgc::deltastate() {
       del_vegs.labn += del_v2v.nresorb[i] - del_v2v.nmobil[i];
     }
   }
+
+//  for (int i=0; i<NUM_PFT_PART; i++) {
+//    BOOST_LOG_SEV(glg, err) << "deltastate - PFT :" << ipft << " - part: " << i << " - vegc: " << del_vegs.c[i] << 
+//    " - npp: " << del_a2v.npp[i] << " - ltrfal: " << del_v2soi.ltrfalc[i] << " - strn: " << del_vegs.strn[i] << 
+//    " - snuptake: " << del_soi2v.snuptake[i] << " - nmobil: " << del_v2v.nmobil[i] << " - nresorb: " << del_v2v.nresorb[i] << " - ltrfaln: " << del_v2soi.ltrfaln[i];
+//  }
+
 };
 
 // summarize some variables not done in 'integrator'
@@ -863,6 +905,10 @@ double  Vegetation_Bgc::getGPP(const double &co2, const double &par,
   gpp *= fpar;
   gpp *= ftemp;
   gpp *= thawpcnt;
+
+// BOOST_LOG_SEV(glg, err) << "pft: " << ipft << ", cmax: " << calpar.cmax << ", foliage: " 
+//              << foliage << ", ci: " << ci << ", fpar: " << fpar << ", ftemp: " 
+//              << ftemp << ", thawpcnt: " << thawpcnt;
 
   if(gpp < 0.0) {
     gpp = 0.0;


### PR DESCRIPTION

Branch name: 
fix_restart

Issue: 
The model has the capacity to conduct new simulations at any stage (e.g. transient, scenario) without having to run the full equilibrium and spinup runs every time. This is done using the restart file that stores the state of every pixel at the last time step of a stage. The issue was that model was generating different outputs for complete simulations  where all stage were run in a continuous series, and simulations initiated reading a restart file.

Main causes of the issue: 
1-	The soil column was not stored correctly in the restart file, and not cleared correctly before initialization.
2-	The temperatures in the parent material were not computed correctly
3-	Time since disturbance was reset to zero when a restart file was used for initialization which impacted canopy-related variables, impacting vegetation C and N dynamic.
4-	Logic of the functions called to compute GPP was not correct at initialization.  

[branch_description.pdf](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/files/11573330/branch_description.pdf)
