### PR TITLE
change GDAL version from 3.2.2 --> 3.2.2.1 in the requirements_mappin…

### DIFF
--- a/requirements_mapping.txt
+++ b/requirements_mapping.txt
@@ -12,7 +12,7 @@ configobj==5.0.6
 cycler==0.10.0
 decorator==4.4.2
 Fiona==1.8.18
-GDAL==3.2.2
+GDAL==3.2.2.1
 geojson==2.5.0
 geopandas==0.8.1
 ipython==8.10.0


### PR DESCRIPTION
update GDAL version from 3.2.2 --> 3.2.2.1 in the requirements_mapping.txt, fixes failure to build the docker mapping support container