### PR TITLE
Fix docker uidgid issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@
 # by passing a --build-arg when running docker build to create your images. See
 # docker-build-wrapper.sh for examples of this pattern in use.
 ARG GIT_VERSION=latest
+ARG UNAME=develop
+ARG UID=1000
+ARG GID=1000
 
 # === IMAGE FOR GENERAL C++ DEVELOPMENT =======================================
 # General development tools, compilers, text editors, etc
@@ -72,10 +75,20 @@ RUN apt-get update -y --fix-missing && apt-get install -y \
     netcdf-bin \
   && rm -rf /var/lib/apt/lists/*
 
-# Make a developer user so as not to always be root
-RUN useradd -ms /bin/bash develop
-RUN echo "develop   ALL=(ALL:ALL) ALL" >> /etc/sudoers
-USER develop
+# Make a developer user so as not to always be root.
+# In order for the resulting container to be able to mount host directories 
+# as volumes and have read/write access, we must be sure that the new user 
+# here has the same UID and GID as the user on the machine hosting the
+# container. Here we have default values for the UNAME, UID and GID, but
+# if you need to you can override them by passing --build-arg to the docker
+# build command.
+ARG UNAME=develop
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u$UID -g$GID -s /bin/bash $UNAME
+RUN echo "$UNAME   ALL=(ALL:ALL) ALL" >> /etc/sudoers
+USER $UNAME
 
 # Pyenv dependencies for building full Python with all extensions.
 USER root
@@ -111,8 +124,8 @@ RUN apt-get update --fix-missing -y && apt-get install -y \
 # but pyenv might be useful for other packages in the future and is a nice
 # unified way to package and version manage our tooling that has been working
 # well across macOS, Ubuntu, CentOS, etc. 
-USER develop
-ENV HOME=/home/develop
+USER $UNAME
+ENV HOME=/home/$UNAME
 RUN git clone https://github.com/pyenv/pyenv.git $HOME/.pyenv
 ENV PYENV_ROOT=$HOME/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
@@ -125,7 +138,7 @@ RUN pip install -U pip pipenv
 COPY requirements_general_dev.txt .
 RUN pip install -r requirements_general_dev.txt
 
-COPY --chown=develop:develop special_configurations/jupyter_notebook_config.py /home/develop/.jupyter/jupyter_notebook_config.py
+COPY --chown=$UNAME:$UNAME special_configurations/jupyter_notebook_config.py /home/$UNAME/.jupyter/jupyter_notebook_config.py
 
 ENV SITE_SPECIFIC_INCLUDES="-I/usr/include/jsoncpp"
 ENV SITE_SPECIFIC_LIBS="-I/usr/lib"
@@ -165,7 +178,7 @@ USER root
 #COPY dvmdostem /work/dvmdostem
 RUN make
 
-USER develop
+USER $UNAME
 # Use this to keep container going when doing docker compose up
 # CMD ["tail -f /dev/null"]
 
@@ -197,7 +210,9 @@ COPY --from=dvmdostem-build /work/config ./config
 # point when an extension is needed, will have to find that shared lib and 
 # copy it in... 
 #  ~800MB
-COPY --from=dvmdostem-build /home/develop/.pyenv /home/develop/.pyenv
+RUN echo ${UNAME}
+FROM ${UNAME} as uname
+COPY --from=dvmdostem-build /home/uname/.pyenv /home/uname/.pyenv
 
 # Discovered by using ldd on compiled binary in testing environment
 COPY --from=dvmdostem-dev /lib/x86_64-linux-gnu/libboost_filesystem.so.1.71.0  /lib/x86_64-linux-gnu/libboost_filesystem.so.1.71.0
@@ -251,10 +266,21 @@ COPY --from=dvmdostem-dev /lib/x86_64-linux-gnu/libsqlite3.so.0 /lib/x86_64-linu
 COPY --from=dvmdostem-dev /lib/x86_64-linux-gnu/libheimbase.so.1 /lib/x86_64-linux-gnu/libheimbase.so.1
 
 # Make a developer user so as not to always be root
-RUN useradd -ms /bin/bash develop
-RUN echo "develop   ALL=(ALL:ALL) ALL" >> /etc/sudoers
-USER develop
-ENV HOME=/home/develop
+# In order for the resulting container to be able to mount host directories 
+# as volumes and have read/write access, we must be sure that the new user 
+# here has the same UID and GID as the user on the machine hosting the
+# container. Here we have default values for the UNAME, UID and GID, but
+# if you need to you can override them by passing --build-arg to the docker
+# build command.
+ARG UNAME=develop
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u$UID -g$GID -s /bin/bash $UNAME
+RUN echo "$UNAME   ALL=(ALL:ALL) ALL" >> /etc/sudoers
+USER $UNAME
+
+ENV HOME=/home/$UNAME
 ENV PYENV_ROOT=$HOME/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 

--- a/Dockerfile-mapping-support
+++ b/Dockerfile-mapping-support
@@ -14,9 +14,19 @@ FROM osgeo/gdal:ubuntu-full-3.2.2
 
 
 # Make a developer user so as not to always be root
-RUN useradd -ms /bin/bash develop
-RUN echo "develop   ALL=(ALL:ALL) ALL" >> /etc/sudoers
-USER develop
+# In order for the resulting container to be able to mount host directories 
+# as volumes and have read/write access, we must be sure that the new user 
+# here has the same UID and GID as the user on the machine hosting the
+# container. Here we have default values for the UNAME, UID and GID, but
+# if you need to you can override them by passing --build-arg to the docker
+# build command.
+ARG UNAME=develop
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u$UID -g$GID -s /bin/bash $UNAME
+RUN echo "$UNAME   ALL=(ALL:ALL) ALL" >> /etc/sudoers
+USER $UNAME
 
 # Pyenv dependencies
 USER root
@@ -43,8 +53,8 @@ RUN apt-get update --fix-missing && apt-get install -y \
 # Pyenv seems to work well for overall python versioning and packagemanagement.
 # Not sure how to best manage pip requirements.txt yet between this mapping
 # support image and the other dvmdostem images.
-USER develop
-ENV HOME=/home/develop
+USER $UNAME
+ENV HOME=/home/$UNAME
 RUN git clone https://github.com/pyenv/pyenv.git $HOME/.pyenv
 ENV PYENV_ROOT=$HOME/.pyenv
 ENV PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
@@ -57,6 +67,16 @@ RUN pip install -U pip pipenv
 RUN pip install setuptools==58
 COPY requirements_mapping.txt .
 RUN pip install -r requirements_mapping.txt
+
+# Pickup some other general development tools...
+USER root
+# Various command line netcdf tools
+RUN apt-get update -y --fix-missing && apt-get install -y \
+    nco \
+    netcdf-bin \
+  && rm -rf /var/lib/apt/lists/*
+
+USER $UNAME
 
 # or use this if not wanting to use requirements.txt...
 # Bug with ipython 7.19.0, so need to downgrade and pin jedi verison

--- a/docker-build-wrapper.sh
+++ b/docker-build-wrapper.sh
@@ -19,10 +19,19 @@
 # appropriately tagged.
 GIT_VERSION=$(git describe --tags)
 
+# This helps with sharing host folders to container. It is important that the
+# user in the container has the same uid/gid as the host user so that both
+# users can have read and write permissions on the files. In many circumstances
+# this build wrapper script will be run with sudo, so we have to find the id 
+# of the login user, not the sudo user, to pass into the guest.
+export HOSTUID=$(id -u $(logname))
+export HOSTGID=$(id -g $(logname))
+
 # IMAGE FOR GENERAL C++ DEVELOPMENT
 # Makes a general development image with various dev tools installed:
 # e.g. compiler, make, gdb, etc
 docker build --build-arg GIT_VERSION=$GIT_VERSION \
+	           --build-arg UID=$HOSTUID --build-arg GID=$HOSTGID \
              --target cpp-dev --tag cpp-dev:$GIT_VERSION .
 
 # IMAGE FOR GENERAL DVMDOSTEM DEVELOPMENT 
@@ -31,7 +40,8 @@ docker build --build-arg GIT_VERSION=$GIT_VERSION \
 # your host machine's repo will be mounted as a volume at /work, and you can
 # use this container as a compile time and run time environment.
 docker build --build-arg GIT_VERSION=$GIT_VERSION \
-             --target dvmdostem-dev --tag dvmdostem-dev:$GIT_VERSION .
+ 	           --build-arg UID=$HOSTUID --build-arg GID=$HOSTGID \
+ 	           --target dvmdostem-dev --tag dvmdostem-dev:$GIT_VERSION .
 
 # IMAGE FOR BUILDING (COMPILING) DVMDOSTEM
 # This is for a stand-alone container that can be used to compile the
@@ -41,17 +51,20 @@ docker build --build-arg GIT_VERSION=$GIT_VERSION \
 # used to create the dvmdostem binary so that it can be copied into
 # the lean run image.
 docker build --build-arg GIT_VERSION=$GIT_VERSION \
+             --build-arg UID=$HOSTUID --build-arg GID=$HOSTGID \
              --target dvmdostem-build --tag dvmdostem-build:$GIT_VERSION .
 
 # IMAGE FOR SIMPLY RUNNING DMVDOSTEM AND ASSOCIATED SCRIPTS
 # A lean images with only the bare minimum stuff to run dvmdostem
 # Does NOT have development tools, compilers, editors, etc
 docker build --build-arg GIT_VERSION=$GIT_VERSION \
+             --build-arg UID=$HOSTUID --build-arg GID=$HOSTGID \
              --target dvmdostem-run --tag dvmdostem-run:$GIT_VERSION .
 
 
 # IMAGE FOR WORKING WITH MAPPING TOOLS, SPECIFICALLY GDAL
 # The bastard step child needed to run various gdal tools
-docker build --build-arg GIT_VERSION=$GIT_VERSION \
+docker build --no-cache --build-arg GIT_VERSION=$GIT_VERSION \
+	           --build-arg UID=$HOSTUID --build-arg GID=$HOSTGID \
              --tag dvmdostem-mapping-support:$GIT_VERSION \
              -f Dockerfile-mapping-support .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ volumes:
   sourcecode:
     driver_opts:
       type: none
-      device: '${PWD}'
+      device: "${PWD}"
       o: bind
   inputcatalog:
     driver_opts:

--- a/scripts/doctests_qcal.md
+++ b/scripts/doctests_qcal.md
@@ -75,13 +75,13 @@ the experiment directory by the `setup_working_directory.py` utility script).
 Now we can make the `QCal` object:
 
     >>> import qcal
-    >>> q = qcal.QCal(
+    >>> q = qcal.QCal( # doctest: +ELLIPSIS
     ...   jsondata_path=os.path.join(TMP_DIR, 'dvmdostem'),
     ...   ncdata_path=os.path.join(TMP_DIR, 'output'), 
     ...   ref_params_dir=os.path.join(TMP_DIR, 'parameters'), 
     ...   ref_targets_dir=os.path.join(TMP_DIR, 'calibration'), y=0, x=0)
     WARNING: No __init__.py python package file present. Copying targets to a temporary location for facilitate import
-    Loading calibration_targets from : ['/tmp/dvmdostem-user-1000-tmp-cal']
+    Loading calibration_targets from : ['/tmp/dvmdostem-user-...-tmp-cal']
     Cleaning up temporary targets and __init__.py file used for import...
     Resetting path...
 


### PR DESCRIPTION
Previously on some systems (Ubuntu) there were problems running as the `develop` user inside the docker containers when using the mounted volumes. The problem had to do with the UID and GID inside the container not matching the UID and GID on the host system. For some reason this was not a problem with macOS or Fedora hosts, perhaps luck with the way UID and GID numbers are assigned on those systems? 

With this fix, the UID and GID of the host are used to set the UID and GID of the `develop` user inside the image/container, allowing the `develop` user to have read/write access to mounted volumes.