### PR TITLE
Remove N mineralization when soil temperature < 0

### DIFF
--- a/include/Soil_Bgc.h
+++ b/include/Soil_Bgc.h
@@ -129,7 +129,8 @@ private:
   double getNetmin(const double & nimmob, const double & soilorgc,
                    const double & soilorgn,
                    const double & rh, const double & tcnsoil,
-                   const double & decay, const double & nup );
+                   const double & decay, const double & nup, const double & soilts );
+
 
   double getKnsoilmoist(const double & vsm);   //
 

--- a/src/Soil_Bgc.cpp
+++ b/src/Soil_Bgc.cpp
@@ -678,7 +678,7 @@ void Soil_Bgc::deltan() {
       del_soi2soi.nimmob[i] = nimmob;
       del_soi2soi.netnmin[i] = getNetmin(nimmob, totc, tmp_sois.orgn[i],
                                          rhsum ,bgcpar.nmincnsoil,
-                                         decay, calpar.micbnup);
+                                         decay, calpar.micbnup, ed->m_sois.ts[i]);
 
       totnetnmin += del_soi2soi.netnmin[i];
     }
@@ -1056,19 +1056,21 @@ double Soil_Bgc::getNimmob(const double & soilh2o, const double & soilorgc,
 double Soil_Bgc::getNetmin(const double & nimmob, const double & soilorgc,
                            const double & soilorgn, const double & rh,
                            const double & tcnsoil,
-                           const double & decay, const double & nup ) {
+                           const double & decay, const double & nup, 
+			   const double & soilts) {
   double nmin = 0.0;
+  if ( soilts > 0.0 ) {
 
-  if ( soilorgc > 0.0 && soilorgn > 0.0 ) {
-    nmin   = ((soilorgn / soilorgc) - (nup * nimmob * decay)) * rh;
+    if ( soilorgc > 0.0 && soilorgn > 0.0 ) {
+      nmin   = ((soilorgn / soilorgc) - (nup * nimmob * decay)) * rh;
 
-    if ( nmin >= 0.0 ) {
-      nmin *= (soilorgn/soilorgc) * tcnsoil;
-    } else {
-      nmin *= (soilorgc/soilorgn) / tcnsoil;
+      if ( nmin >= 0.0 ) {
+        nmin *= (soilorgn/soilorgc) * tcnsoil;
+      } else {
+        nmin *= (soilorgc/soilorgn) / tcnsoil;
+      }
     }
   }
-
   return nmin;
 };
 


### PR DESCRIPTION
Recent updates to the model allow heterotrophic respiration in the winter, and in effect N mineralization occurs at soil temps below 0 C. Currently the model does not support N immobilization at soil temps below 0 C. This imbalance in the winter N cycle caused a runaway available nitrogen effect. The fix is to turn off N mineralization at sub-zero soil temperatures. Current literature does not support implementing wintertime N cycling in the model, so the conservative solution is to keep it off.

Figures are from 2,000 years of equilibrium at CMT13 (not part of master), a black spruce peatland under calibration for the Poker Flats Ameriflux site.

![AVLN](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/e6c2d301-5802-4e1e-8f0f-8a59059244ba)
![AVLN2](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/36635c65-31a0-4125-9f01-8a5c293bb2db)
![GPP](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/1aca124c-da5a-461c-83d2-91d72bfa46f2)
![RH](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/b55078f6-34d8-442d-90ff-79d845739d1e)
![LTRFALC](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/9644947a-e9df-4f64-969a-78923ee0b95b)
![SHLWC](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/40a2d713-05c1-43a9-94dd-921798892a5c)
![DEEPC](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/3187e6f1-af4e-43dd-932e-fe20a61f7c2e)
![ORGN](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/4f60cc6c-0209-4b50-8509-dc3507e70e0a)
