### PR TITLE
Remove version requirement for Jinja template library.

### DIFF
--- a/requirements_mapping.txt
+++ b/requirements_mapping.txt
@@ -18,7 +18,7 @@ geopandas==0.8.1
 ipython==8.10.0
 ipython-genutils==0.2.0
 jedi==0.17.2
-Jinja2==3.1.3
+Jinja2
 kiwisolver==1.2.0
 lark-parser==0.7.8
 MarkupSafe==1.1.1


### PR DESCRIPTION
There might be a better way to do this (maybe a range of versions?) however this allows the build to work and we are not heavily using the Jinja library, so should not be too sensitive to the version.