### PR TITLE
Fix the dependency error when building the images

### DIFF
--- a/requirements_mapping.txt
+++ b/requirements_mapping.txt
@@ -21,7 +21,7 @@ jedi==0.17.2
 Jinja2==3.1.3
 kiwisolver==1.2.0
 lark-parser==0.7.8
-MarkupSafe==1.1.1
+MarkupSafe==2.0
 matplotlib==3.3.1
 munch==2.5.0
 netCDF4==1.5.4


### PR DESCRIPTION
When running `sudo bash docker-build-wrapper.sh -a` command, the script throws the following error:

```
INFO: pip is looking at multiple versions of jinja2 to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements_mapping.txt (line 21) and MarkupSafe==1.1.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested MarkupSafe==1.1.1
    jinja2 3.1.3 depends on MarkupSafe>=2.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
The command '/bin/sh -c pip install -r requirements_mapping.txt' returned a non-zero code: 1
```

Fixes #691 