### PR TITLE
Turn off "squeezing" dimensions of subplots when plotting Sensitivity…

### DIFF
--- a/scripts/drivers/Sensitivity.py
+++ b/scripts/drivers/Sensitivity.py
@@ -1462,7 +1462,8 @@ class Sensitivity(BaseDriver):
     None
     '''
 
-    fig, axes = plt.subplots(len(self.params),3, figsize=(10,3*len(self.params)))
+    fig, axes = plt.subplots(len(self.params), 3, 
+                             figsize=(10, 3*len(self.params)), squeeze=False)
 
     for i, (p, ax) in enumerate(zip(self.params, axes)):
       ax[0].plot(self.sample_matrix.iloc[:, i], marker='.', linewidth=0, alpha=.5)


### PR DESCRIPTION
… parameters.

By default if you call plt.subplots(...) with a dimension of 1 for rows or columns, it "squeezes" that dimension out, which changes the dimensions of the returned object (list of Axes.Subplots). In this case that is not desireable because later code tries to index into this list.