### PR TITLE
Baseline climate config

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -122,8 +122,8 @@
 
   "model_settings": {
     "dynamic_lai": 1,                   // from model (1) or from input (0)
-    "baseline_start": 1901,  //start year for baseline EQ/SP climate
-    "baseline_end": 1931     //end year for baseline EQ/SP climate
+    "baseline_start": 1901,  //start year for baseline EQ climate
+    "baseline_end": 1931     //end year for baseline EQ climate
 //    //"dynamic_climate": 0,
 //    //"varied_co2": 0,
 //    //"fire_severity_as_input": 0,    // fire sev. as input or ??

--- a/config/config.js
+++ b/config/config.js
@@ -121,7 +121,9 @@
   },
 
   "model_settings": {
-    "dynamic_lai": 1                    // from model (1) or from input (0)
+    "dynamic_lai": 1,                   // from model (1) or from input (0)
+    "baseline_start": 1901,  //start year for baseline EQ/SP climate
+    "baseline_end": 1931     //end year for baseline EQ/SP climate
 //    //"dynamic_climate": 0,
 //    //"varied_co2": 0,
 //    //"fire_severity_as_input": 0,    // fire sev. as input or ??

--- a/include/Climate.h
+++ b/include/Climate.h
@@ -10,10 +10,16 @@ public:
   Climate();
   Climate(const std::string& fname, const std::string& co2fname, int y, int x);
 
-  // misc climate variables
-  // This value will change during a run when switching from
+  // Misc. climate variables
+  // The following two values determine the span of historic climate
+  //  years used to produce a baseline average climate for EQ
+  //  TODO: SP repeated climate is not currently affected by these.
+  int baseline_start;
+  int baseline_end;
+  // These values will change during a run when switching from
   //  historic to projected climate data
   int tseries_start_year;
+  int tseries_end_year;
 
   // driving variables
   std::vector<float> co2;
@@ -74,6 +80,8 @@ public:
 
   void load_proj_climate(const std::string&, int, int);
   void load_proj_co2(const std::string&);
+
+  void prep_avg_climate();
 
 private:
 

--- a/include/ModelData.h
+++ b/include/ModelData.h
@@ -86,6 +86,10 @@ public:
   bool nc_tr;
   bool nc_sc;
   int output_interval; //How many years to store for output
+  //The following two config values are temporarily stored in
+  // ModelData, to be transferred to Climate.
+  int baseline_start;//Start year for baseline EQ climate
+  int baseline_end;//End year for baseline EQ climate
 
   // Maps holding data about variables to be output at specific timesteps
   // C++11 would allow the use of unordered_maps, which have a faster

--- a/include/TEMUtilityFunctions.h
+++ b/include/TEMUtilityFunctions.h
@@ -145,6 +145,7 @@ namespace temutil {
                                     const int y, const int x);
 
   int get_timeseries_start_year(const std::string &filename);
+  int get_timeseries_end_year(const std::string &filename);
 
   // draft - reads all timesteps co2 data
   std::vector<float> get_timeseries(const std::string &filename,

--- a/src/Climate.cpp
+++ b/src/Climate.cpp
@@ -484,8 +484,7 @@ void Climate::load_from_file(const std::string& fname, int y, int x) {
 */
 void Climate::prep_avg_climate(){
   BOOST_LOG_SEV(glg, debug) << "Climate baseline from config: "
-                            << this->climate.baseline_start << ":"
-                            << this->climate.baseline_end;
+                            << baseline_start << ":" << baseline_end;
 
   if(   baseline_start > tseries_end_year
      || baseline_start < tseries_start_year
@@ -495,6 +494,13 @@ void Climate::prep_avg_climate(){
     BOOST_LOG_SEV(glg, fatal) << "Baseline year value exceeds range"
              << " of input file.\n" << "Acceptable range: "
              << tseries_start_year << ":" << tseries_end_year << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if(baseline_end < baseline_start){
+    BOOST_LOG_SEV(glg, fatal) << "Baseline end year " << baseline_end
+                              << " is less than baseline start year "
+                              << baseline_start;
     exit(EXIT_FAILURE);
   }
 

--- a/src/Cohort.cpp
+++ b/src/Cohort.cpp
@@ -63,13 +63,17 @@ Cohort::Cohort(int y, int x, ModelData* modeldatapointer):
 
   // might need to set the cd* and the ed* ???
 
-  BOOST_LOG_SEV(glg, debug) << "Setup the NEW STYLE CLIMATE OBJECT ...";
-  // FIX: Historic? Projected?? how to handle both??
-  // Maybe:
-  //this->hist_climate = Climate(modeldatapointer->hist_climate, y, x);
-  //this->proj_climate = Climate(modeldatapointer->proj_climate, y, x);
+  BOOST_LOG_SEV(glg, debug) << "Construct Climate object ...";
+
+  //On construction we assume historic climate, which will be
+  // overwritten by projected climate later when necessary.
   this->climate = Climate(modeldatapointer->hist_climate_file, modeldatapointer->co2_file, y, x);
-  
+
+  this->climate.baseline_start = modeldatapointer->baseline_start;
+  this->climate.baseline_end = modeldatapointer->baseline_end;
+  //Prepare averaged input set for EQ stage
+  this->climate.prep_avg_climate();
+
   // Build a mineral info object
   MineralInfo mineral_info = MineralInfo(modeldatapointer->soil_texture_file, y, x);
 
@@ -853,6 +857,7 @@ void Cohort::updateMonthly_DIMveg(const int & currmind, const bool & dynamic_lai
   for (int ip=0; ip<NUM_PFT; ip++) {
     if (cd.m_veg.vegcov[ip]>0.) {
       cd.m_veg.vegage[ip] = cd.yrsdist;
+
       if (cd.m_veg.vegage[ip]<=0) {
         cd.m_vegd.foliagemx[ip] = 0.;
       }
@@ -1518,4 +1523,3 @@ void Cohort::set_restartdata_from_state() {
     }
   }
 }
-

--- a/src/ModelData.cpp
+++ b/src/ModelData.cpp
@@ -112,6 +112,8 @@ ModelData::ModelData(Json::Value controldata):force_cmt(-1) {
   caldata_tree_loc  = controldata["calibration-IO"]["caldata_tree_loc"].asString();
 
   dynamic_LAI       = controldata["model_settings"]["dynamic_lai"].asInt(); // checked in Cohort::updateMonthly_DIMVeg
+  baseline_start = controldata["model_settings"]["baseline_start"].asInt();
+  baseline_end   = controldata["model_settings"]["baseline_end"].asInt();
 
   // Unused (11/23/2015)
   //changeclimate = controldata["model_settings"]["dynamic_climate"].asInt();


### PR DESCRIPTION
This moves the calendar year range selection for EQ averaged climate to the
config file for easier modification without recompiling. It includes basic
checks for the specified years being out of bounds for the input file or the
end year being prior to the start year.

Testing for non-EQ stages was done manually by directly comparing the
netCDF files from a full demo run.
Testing for EQ stage:
[result.pdf](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/files/15156097/result.pdf)
