### PR TITLE
Simplify `ParentLayer.cpp` and `SnowLayer.cpp`

### DIFF
--- a/src/ParentLayer.cpp
+++ b/src/ParentLayer.cpp
@@ -27,15 +27,23 @@ void ParentLayer::updateProperty() {
   vhcsolid = 2700000;
 };
 
-// get frozen layer specific heat capcity
+// Note: Though the following functions return the same value,
+// they require different names to work inside TemperatureUpdator.cpp
+// where these will be called by name and not by layer type. 
+// Hence they must match with the functions used in Layer.cpp
+// and SoilLayer.cpp.
+
+// get frozen layer volumetric heat capacity
 double ParentLayer::getFrzVolHeatCapa() {
   return vhcsolid;
 };
 
+// get unfrozen layer volumetric heat capacity
 double ParentLayer::getUnfVolHeatCapa() {
   return vhcsolid;
 };
 
+// get mixed (partially frozen) layer volumetric heat capacity
 double ParentLayer::getMixVolHeatCapa() {
   return vhcsolid;
 };

--- a/src/ParentLayer.cpp
+++ b/src/ParentLayer.cpp
@@ -29,30 +29,25 @@ void ParentLayer::updateProperty() {
 
 // get frozen layer specific heat capcity
 double ParentLayer::getFrzVolHeatCapa() {
-  double vhc = vhcsolid ;
-  return vhc;
+  return vhcsolid;
 };
 
 double ParentLayer::getUnfVolHeatCapa() {
-  double vhc= vhcsolid ;
-  return vhc;
+  return vhcsolid;
 };
 
 double ParentLayer::getMixVolHeatCapa() {
-  double vhc= vhcsolid ;
-  return vhc;
+  return vhcsolid;
 };
 
 // get frozen layer thermal conductivity
 double ParentLayer::getFrzThermCond() {
-  double tc=tcsolid;
-  return tc;
+  return tcsolid;
 };
 
 // get unfrozen layer thermal conductivity
 double ParentLayer::getUnfThermCond() {
-  double tc=tcsolid;
-  return tc;
+  return tcsolid;
 };
 
 // get albedo of visible radiation

--- a/src/SnowLayer.cpp
+++ b/src/SnowLayer.cpp
@@ -102,34 +102,15 @@ double SnowLayer::getThermCond() {
   return tc;
 }
 
-// FIX THIS: THESE 3 functions see to be identical???
 double SnowLayer::getFrzVolHeatCapa() {
-  if (dz != 0) {
-    // FIX THIS: divide by zero error when there is no thickness!
-    double vhc = SHCICE * ice/dz;
-    return vhc;
-  } else {
-    return 0;
-  }
+  return (dz != 0) ? (SHCICE * ice/dz) : 0;
 };
 
 double SnowLayer::getUnfVolHeatCapa() {
-  if (dz != 0) {
-    // FIX THIS: divide by zero error when there is no thickness!
-    double vhc = SHCICE * ice/dz;
-    return vhc;
-  } else {
-    return 0;
-  }
+  return (dz != 0) ? (SHCICE * ice/dz) : 0;
 };
 
 double SnowLayer::getMixVolHeatCapa() {
-  if (dz != 0) {
-    // FIX THIS: divide by zero error when there is no thickness!
-    double vhc = SHCICE * ice/dz;
-    return vhc;
-  } else {
-    return 0;
-  }
+  return (dz != 0) ? (SHCICE * ice/dz) : 0;
 };
 

--- a/src/SnowLayer.cpp
+++ b/src/SnowLayer.cpp
@@ -102,6 +102,12 @@ double SnowLayer::getThermCond() {
   return tc;
 }
 
+// Note: Though the following functions return the same value,
+// they require different names to work inside TemperatureUpdator.cpp
+// where these will be called by name and not by layer type. 
+// Hence they must match with the functions used in Layer.cpp
+// and SoilLayer.cpp.
+
 double SnowLayer::getFrzVolHeatCapa() {
   return (dz != 0) ? (SHCICE * ice/dz) : 0;
 };


### PR DESCRIPTION
`Layer` class has the following virtual methods:

```cpp
virtual double getFrzThermCond()=0; // get frozen layer thermal conductivity
virtual double getUnfThermCond()=0; // get unfrozen layer thermal conductivity
virtual double getFrzVolHeatCapa()=0;// get frozen layer specific heat capcity
virtual double getUnfVolHeatCapa()=0;// get unfrozen layer specific heat capacity
virtual double getMixVolHeatCapa()=0;//Yuan
```

The implementation of some of these methods are same in `ParentLayer.cpp` and `SnowLayer.cpp`. We cannot merge the same methods in a single method. So, this PR attempts to explain why these methods have the same implementation. It also cleans up the method implementation.