### PR TITLE
fix frootfrac re-adjustment to frootfrac cannot be nan

### DIFF
--- a/src/WildFire.cpp
+++ b/src/WildFire.cpp
@@ -286,13 +286,19 @@ void WildFire::burn(int year) {
   BOOST_LOG_SEV(glg, note) << "Re-do the soil root fraction for each PFT modified by burning?";
   for (int ip = 0; ip < NUM_PFT; ip++) {
     double rootfracsum = 0.0;
-
     for (int il = 0; il < cd->m_soil.numsl; il++) {
-      rootfracsum += cd->m_soil.frootfrac[il][ip];
+      if (cd->m_soil.type[il]>0 && cd->m_soil.frootfrac[il][ip]>0.) {
+        rootfracsum += cd->m_soil.frootfrac[il][ip];
+      }
     }
 
     for (int il =0; il <cd->m_soil.numsl; il++) {
-      cd->m_soil.frootfrac[il][ip] /= rootfracsum;
+      if (cd->m_soil.type[il]>0 && cd->m_soil.frootfrac[il][ip]>0. && rootfracsum>0.) {
+        cd->m_soil.frootfrac[il][ip] /= rootfracsum;
+      }
+      else {
+        cd->m_soil.frootfrac[il][ip] = 0.0;
+        }
     }
   }
 


### PR DESCRIPTION
Remove potential for divide by zero resulting in cd->m_soil.frootfrac = nan. Previously this would occur in the moss layer where rootfracsum = 0. Added a few checks to avoid this, some of which may be redundant, but fixes the problem.

## Output  before fix (See AVLN row):
 
![Pools_fire_exps](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/f935ce71-a75f-48be-9549-af13b784d47e)

## Output after fix (See AVLN row):

![Pools_fire_exps_AVLN_fix](https://github.com/uaf-arctic-eco-modeling/dvm-dos-tem/assets/16657080/dc7a3a45-49a9-4dfd-b69f-0441972e26ac)

