### PR TITLE
Corrects order of fronts copied from RD to Ground

### DIFF
--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -561,8 +561,8 @@ void Ground::set_state_from_restartdata(snwstate_dim *snowdim,
 
   for(int ifnt = 0; ifnt<MAX_NUM_FNT; ifnt++) {
     if(frontZ[ifnt]>0.) {
-      frontsz.push_front(frontZ[ifnt]);
-      frontstype.push_front(frontFT[ifnt]);
+      frontsz.push_back(frontZ[ifnt]);
+      frontstype.push_back(frontFT[ifnt]);
     }
   }
 


### PR DESCRIPTION
The fronts were being inverted (what should have been on top was on the
bottom), which caused issues when there was a talik present at stage change.