### PR TITLE
Modify/improve MadsTEMDriver.observed_vec function, fix bug.

### DIFF
--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -273,10 +273,7 @@ println("targets=np.array(", targets, "),")
 
 # Generate a list of nicely formatted labels that can be used for plotting
 # These labels are for the output variables (aka calibration targets)
-
-### Suggestion for correcting outlabels issue:
 outlabels = []
-
 for x in dvmdostem.gather_model_outputs()
 
   if haskey(x, "pft") && haskey(x, "cmprt")
@@ -288,11 +285,10 @@ for x in dvmdostem.gather_model_outputs()
   else
     push!(outlabels, string(x["ctname"]))
   end
+
 end
 
 
-
-# outlabels=[string(x["ctname"],"_pft",x["pft"]) for x in dvmdostem.gather_model_outputs()]
 println("out_labels=", outlabels)
 println("")
 

--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -108,7 +108,7 @@ dvmdostem = PyCall.py"load_dvmdostem_from_configfile"(config_file)
 # ridden from the mads config (parameter distributions, intial guesses, etc)
 
 # Save the targets...
-targets = dvmdostem.observed_vec(format="flat")
+targets = dvmdostem.observed_vec(format='flat')
 
 # Do the seed run and keep the results
 println("Performing seed run...")

--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -273,6 +273,25 @@ println("targets=np.array(", targets, "),")
 
 # Generate a list of nicely formatted labels that can be used for plotting
 # These labels are for the output variables (aka calibration targets)
+
+### Suggestion for correcting outlabels issue:
+# outlabels = []
+
+# for x in dvmdostem.gather_model_outputs()
+
+#   if "pft" in keys(x) && "pftpart" in keys(x)
+#     push!(outlabels, string(x["ctname"], "_pft", x["pft"], "_", x["pftpart"]))
+
+#   elseif "pft" in keys(x) && "pftpart" not in keys(x)
+#     push!(outlabels, string(x["ctname"], "_pft", x["pft"]))
+
+#   else
+#     push!(outlabels, string(x["ctname"]))
+#   end
+# end
+
+
+
 outlabels=[string(x["ctname"],"_pft",x["pft"]) for x in dvmdostem.gather_model_outputs()]
 println("out_labels=", outlabels)
 println("")

--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -108,7 +108,7 @@ dvmdostem = PyCall.py"load_dvmdostem_from_configfile"(config_file)
 # ridden from the mads config (parameter distributions, intial guesses, etc)
 
 # Save the targets...
-targets = dvmdostem.observed_vec(format='flat')
+targets = dvmdostem.observed_vec(format="flat")
 
 # Do the seed run and keep the results
 println("Performing seed run...")

--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -275,24 +275,24 @@ println("targets=np.array(", targets, "),")
 # These labels are for the output variables (aka calibration targets)
 
 ### Suggestion for correcting outlabels issue:
-# outlabels = []
+outlabels = []
 
-# for x in dvmdostem.gather_model_outputs()
+for x in dvmdostem.gather_model_outputs()
 
-#   if "pft" in keys(x) && "pftpart" in keys(x)
-#     push!(outlabels, string(x["ctname"], "_pft", x["pft"], "_", x["pftpart"]))
+  if haskey(x, "pft") && haskey(x, "cmprt")
+    push!(outlabels, string(x["ctname"], "_pft", x["pft"], "_", x["cmprt"]))
 
-#   elseif "pft" in keys(x) && "pftpart" not in keys(x)
-#     push!(outlabels, string(x["ctname"], "_pft", x["pft"]))
+  elseif haskey(x, "pft") && !haskey(x, "cmprt")
+    push!(outlabels, string(x["ctname"], "_pft", x["pft"]))
 
-#   else
-#     push!(outlabels, string(x["ctname"]))
-#   end
-# end
+  else
+    push!(outlabels, string(x["ctname"]))
+  end
+end
 
 
 
-outlabels=[string(x["ctname"],"_pft",x["pft"]) for x in dvmdostem.gather_model_outputs()]
+# outlabels=[string(x["ctname"],"_pft",x["pft"]) for x in dvmdostem.gather_model_outputs()]
 println("out_labels=", outlabels)
 println("")
 

--- a/mads_calibration/AC-MADS-TEM.jl
+++ b/mads_calibration/AC-MADS-TEM.jl
@@ -108,7 +108,7 @@ dvmdostem = PyCall.py"load_dvmdostem_from_configfile"(config_file)
 # ridden from the mads config (parameter distributions, intial guesses, etc)
 
 # Save the targets...
-targets = dvmdostem.observed_vec()
+targets = dvmdostem.observed_vec(format='flat')
 
 # Do the seed run and keep the results
 println("Performing seed run...")

--- a/mads_calibration/ca-config-demo.yaml
+++ b/mads_calibration/ca-config-demo.yaml
@@ -5,7 +5,7 @@ mads_problemname: last_test
 
 # The location where your model run will be conducted and where your 
 # iteration and final results will be copied to at the end of the run(s)
-work_dir: /data/workflows/calibration/CMT06-IMNAVIAT/output/cmax_gppallignoringnitrogen/ca
+work_dir: /data/workflows/calibration/CMT06-TOOLIK/output/cmax_gppallignoringnitrogen/ca
 
 # The path to the "seed" directory that parameter will be read from. This could
 # be the main repository (/work/parameters if you are working inside the 
@@ -14,8 +14,8 @@ work_dir: /data/workflows/calibration/CMT06-IMNAVIAT/output/cmax_gppallignoringn
 # the strucutre of the calibration project you are working on. 
 seed_path: /work/parameters
 
-# The path to the driving input data set that will be used
-site: /data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10
+# The path to the driving input data set that will be used.
+site: /work/demo-data/cru-ts40_ar5_rcp85_ncar-ccsm4_toolik_field_station_10x10
 
 # The pixel from the driving inputs that iwll be used.
 PXx: 0

--- a/scripts/tests/doctests/doctests_MadsTEMDriver.rst
+++ b/scripts/tests/doctests/doctests_MadsTEMDriver.rst
@@ -5,7 +5,7 @@
 
 >>> my_yaml_string = """
 ... work_dir: /tmp/test_CA
-... site: /data/input-catalog/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10
+... site: /work/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10
 ... PXx: 0
 ... PXy: 0
 ... calib_mode: GPPAllIgnoringNitrogen

--- a/scripts/tests/doctests/doctests_MadsTEMDriver.rst
+++ b/scripts/tests/doctests/doctests_MadsTEMDriver.rst
@@ -52,8 +52,52 @@
 
 >>> d.setup_outputs(d.target_names)
 
->>> d.observed_vec()
+Grab the targets in two differnt formats (flat and labeled) and make sure the 
+values line up as expected.
+
+>>> import pandas as pd
+
+>>> flat_targets = d.observed_vec(format='flat')
+>>> df_targets = pd.DataFrame(d.observed_vec(format='labeled'))
+
+Check on the first block of data, which is a PFT target, but not by compartment.
+First print out the tables so we can see the expected shapes.
+>>> df_targets.loc[df_targets['ctname'] == 'GPPAllIgnoringNitrogen']
+   cmtnum                  ctname  pft  observed cmprt
+0       6  GPPAllIgnoringNitrogen    0    11.833   NaN
+1       6  GPPAllIgnoringNitrogen    1   197.867   NaN
+2       6  GPPAllIgnoringNitrogen    2    42.987   NaN
+3       6  GPPAllIgnoringNitrogen    3    10.667   NaN
+4       6  GPPAllIgnoringNitrogen    4     3.375   NaN
+5       6  GPPAllIgnoringNitrogen    5    16.000   NaN
+6       6  GPPAllIgnoringNitrogen    6     6.000   NaN
+>>> flat_targets[0:len(d.pftnums)]
 [11.833, 197.867, 42.987, 10.667, 3.375, 16.0, 6.0]
+
+Then actually check the data so that we are confident in the output order for
+the flat list.
+>>> a = flat_targets[0:len(d.pftnums)]
+>>> b = df_targets.loc[df_targets['ctname'] == 'GPPAllIgnoringNitrogen']['observed']
+>>> all(a == b)
+True
+
+Then check on some compartment data. First print out the tables of data so we 
+can see the expected shapes.
+
+>>> flat_targets[len(d.pftnums):len(d.pftnums)+3]
+[2.0, 4.0, 0.297]
+>>> df_targets.loc[ (df_targets['ctname']=='VegCarbon') & (df_targets['pft']==0) ]
+   cmtnum     ctname  pft  observed cmprt
+7       6  VegCarbon    0     2.000  Leaf
+8       6  VegCarbon    0     4.000  Stem
+9       6  VegCarbon    0     0.297  Root
+
+Then check the data so that we are confident that we understand the ordering.
+
+>>> a = flat_targets[len(d.pftnums):len(d.pftnums)+3]
+>>> b = df_targets.loc[ (df_targets['ctname']=='VegCarbon') & (df_targets['pft']==0) ]['observed']
+>>> all(a == b)
+True
 
 >>> d.params_vec()
 [22.8, 250.6, 65.0, 38.5, 7.8, 21.0, 36.3]
@@ -77,9 +121,27 @@ This makes sense because we haven't run the model yet so there are no outputs.
 
 >>> final_data = d.gather_model_outputs()
 >>> import pandas as pd
+>>> df_finaldata = pd.DataFrame(final_data)
+>>> df_finaldata.loc[(df_finaldata['ctname']=='VegCarbon') & (df_finaldata['cmprt']=='Leaf')]
+      cmt     ctname      value  truth  pft cmprt
+7   CMT06  VegCarbon   2.138998   2.00    0  Leaf
+10  CMT06  VegCarbon  42.925257  37.10    1  Leaf
+12  CMT06  VegCarbon   0.156739   8.06    2  Leaf
+14  CMT06  VegCarbon   2.602119   2.00    3  Leaf
+16  CMT06  VegCarbon   2.250932   2.00    4  Leaf
+17  CMT06  VegCarbon  22.572059  22.00    5  Leaf
+18  CMT06  VegCarbon  22.400614  23.00    6  Leaf
 
-.. 
-  >>> #pd.DataFrame(final_data)
-  >>> #print(final_data)
-  >>> #print(d.params)
+Now check that the observed values that are put in the final output data are
+indeed the same as the observed values that are read and setup in the
+`self.targets` datastructure before running the model. This is harder because in
+the outputs, there are only rows for valid PFT/compartment combos, whereas in 
+the targets dataframe, there are rows with zero values for the observations for
+PFT/compartment combos that are not defined...for example the Stem and Root 
+compartments are not set for Lichen, but in the targets, there are (empty) rows
+for them. So here we drop the empty rows, and then compare with the final data.
 
+>>> a = df_targets.loc[ (df_targets['ctname']=='VegCarbon') & (df_targets['pft']==2) ]['observed']
+>>> b = df_finaldata.loc[ (df_finaldata['ctname']=='VegCarbon') & (df_finaldata['pft']==2) ]['truth']
+>>> all( a[a>0].values == b.values ) 
+True

--- a/scripts/tests/doctests/doctests_MadsTEMDriver_alltypestargets.rst
+++ b/scripts/tests/doctests/doctests_MadsTEMDriver_alltypestargets.rst
@@ -96,28 +96,41 @@ This makes sense because we haven't run the model yet so there are no outputs.
 
 >>> d.run()
 
+Collect the model outputs and then stuff them into a DataFrame for easy
+analysis.
+
 >>> final_data = d.gather_model_outputs()
 >>> import pandas as pd
 >>> df_finaldata = pd.DataFrame(final_data)
->>> df_finaldata
-      cmt                  ctname       value    truth  pft cmprt
-0   CMT06  GPPAllIgnoringNitrogen    9.008573   11.833  0.0   NaN
-1   CMT06  GPPAllIgnoringNitrogen  133.687429  197.867  1.0   NaN
-2   CMT06  GPPAllIgnoringNitrogen   25.611490   42.987  2.0   NaN
-3   CMT06  GPPAllIgnoringNitrogen    7.791676   10.667  3.0   NaN
-4   CMT06  GPPAllIgnoringNitrogen    3.388915    3.375  4.0   NaN
-5   CMT06  GPPAllIgnoringNitrogen    9.705867   16.000  5.0   NaN
-6   CMT06  GPPAllIgnoringNitrogen   17.169587    6.000  6.0   NaN
-7   CMT06              MossDeathC   10.570156  178.000  NaN   NaN
-8   CMT06               VegCarbon    2.138998    2.000  0.0  Leaf
-9   CMT06               VegCarbon    4.117513    4.000  0.0  Stem
-10  CMT06               VegCarbon    0.340910    0.297  0.0  Root
-11  CMT06               VegCarbon   42.925257   37.100  1.0  Leaf
-12  CMT06               VegCarbon  280.460292  161.280  1.0  Root
-13  CMT06               VegCarbon    0.156739    8.060  2.0  Leaf
-14  CMT06               VegCarbon   96.316317   11.040  2.0  Root
-15  CMT06               VegCarbon    2.602119    2.000  3.0  Leaf
-16  CMT06               VegCarbon    2.664471    3.200  3.0  Root
-17  CMT06               VegCarbon    2.250932    2.000  4.0  Leaf
-18  CMT06               VegCarbon   22.572059   22.000  5.0  Leaf
-19  CMT06               VegCarbon   22.400614   23.000  6.0  Leaf
+>>> df_finaldata.info()
+<class 'pandas.core.frame.DataFrame'>
+RangeIndex: 20 entries, 0 to 19
+Data columns (total 6 columns):
+ #   Column  Non-Null Count  Dtype  
+---  ------  --------------  -----  
+ 0   cmt     20 non-null     object 
+ 1   ctname  20 non-null     object 
+ 2   value   20 non-null     float64
+ 3   truth   20 non-null     float64
+ 4   pft     19 non-null     float64
+ 5   cmprt   12 non-null     object 
+dtypes: float64(3), object(3)
+memory usage: 1.1+ KB
+
+Print out the top and bottom of the frame.
+
+>>> df_finaldata.head()
+     cmt                  ctname       value    truth  pft cmprt
+0  CMT06  GPPAllIgnoringNitrogen    9.008573   11.833  0.0   NaN
+1  CMT06  GPPAllIgnoringNitrogen  133.687429  197.867  1.0   NaN
+2  CMT06  GPPAllIgnoringNitrogen   25.611490   42.987  2.0   NaN
+3  CMT06  GPPAllIgnoringNitrogen    7.791676   10.667  3.0   NaN
+4  CMT06  GPPAllIgnoringNitrogen    3.388915    3.375  4.0   NaN
+
+>>> df_finaldata.tail()
+      cmt     ctname      value  truth  pft cmprt
+15  CMT06  VegCarbon   2.602119    2.0  3.0  Leaf
+16  CMT06  VegCarbon   2.664471    3.2  3.0  Root
+17  CMT06  VegCarbon   2.250932    2.0  4.0  Leaf
+18  CMT06  VegCarbon  22.572059   22.0  5.0  Leaf
+19  CMT06  VegCarbon  22.400614   23.0  6.0  Leaf

--- a/scripts/tests/doctests/doctests_MadsTEMDriver_alltypestargets.rst
+++ b/scripts/tests/doctests/doctests_MadsTEMDriver_alltypestargets.rst
@@ -1,0 +1,123 @@
+# Testing, developing and describing the interface for MadsTEMDriver.py
+=========================================================================
+
+This file is intended to test that the driver can work with all three types of
+targets specified (soil, PFT, PFT-compartment).
+
+>>> import yaml
+
+>>> my_yaml_string = """
+... work_dir: /tmp/test_CA
+... site: /work/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10
+... PXx: 0
+... PXy: 0
+... calib_mode: GPPAllIgnoringNitrogen
+... target_names: 
+... - GPPAllIgnoringNitrogen
+... - MossDeathC
+... - VegCarbon
+... cmtnum: 6
+... opt_run_setup: --pr-yrs 5 --eq-yrs 10 --sp-yrs 0 --tr-yrs 0 --sc-yrs 0
+... params:
+... - cmax
+... - cmax
+... - cmax
+... - cmax
+... - cmax
+... - cmax
+... - cmax
+... pftnums:
+... - 0
+... - 1
+... - 2
+... - 3
+... - 4
+... - 5
+... - 6
+... """
+
+>>> config_dict = yaml.load(my_yaml_string, Loader=yaml.FullLoader)
+
+>>> import drivers.MadsTEMDriver
+
+>>> d = drivers.MadsTEMDriver.MadsTEMDriver(config_dict)
+
+>>> d.set_seed_path('/work/parameters')
+
+>>> d.set_params_from_seed()
+
+>>> d.load_target_data(ref_target_path='/work/calibration/')
+
+>>> d.setup_outputs(d.target_names)
+
+Grab the targets in two differnt formats (flat and labeled) and make sure the
+values line up as expected. 
+
+>>> import pandas as pd
+
+>>> flat_targets = d.observed_vec(format='flat')
+>>> df_targets = pd.DataFrame(d.observed_vec(format='labeled'))
+
+Check on the first block of data, which is a PFT target, but not by compartment.
+First print out the tables so we can see the expected shapes.
+
+>>> df_targets.loc[df_targets['ctname'] == 'MossDeathC']
+   cmtnum      ctname  pft  observed cmprt
+7       6  MossDeathC  NaN     178.0   NaN
+
+Then actually check the data so that we are confident in the output order for
+the flat list.
+
+
+Then check on some compartment data. Here we need to make sure that only targets
+are included for PFTs, and compartments that are defined. So for example while
+the main targets data structure includes zero for undefined PFTs and
+compartments, these zero values should not be present in the `.observed_vec()`
+outputs. E.g.:
+
+>>> d.targets['VegCarbon']['Leaf']
+[2.0, 37.1, 8.06, 2.0, 2.0, 22.0, 23.0, 0.0, 0.0, 0.0]
+
+versus
+
+>>> df_targets.loc[(df_targets['ctname']=='VegCarbon') & (df_targets['pft']==4)]
+    cmtnum     ctname  pft  observed cmprt
+17       6  VegCarbon  4.0       2.0  Leaf
+
+
+>>> d.params_vec()
+[22.8, 250.6, 65.0, 38.5, 7.8, 21.0, 36.3]
+
+This makes sense because we haven't run the model yet so there are no outputs.
+
+>>> d.clean()
+
+>>> d.setup_run_dir()
+
+>>> d.run()
+
+>>> final_data = d.gather_model_outputs()
+>>> import pandas as pd
+>>> df_finaldata = pd.DataFrame(final_data)
+>>> df_finaldata
+      cmt                  ctname       value    truth  pft cmprt
+0   CMT06  GPPAllIgnoringNitrogen    9.008573   11.833  0.0   NaN
+1   CMT06  GPPAllIgnoringNitrogen  133.687429  197.867  1.0   NaN
+2   CMT06  GPPAllIgnoringNitrogen   25.611490   42.987  2.0   NaN
+3   CMT06  GPPAllIgnoringNitrogen    7.791676   10.667  3.0   NaN
+4   CMT06  GPPAllIgnoringNitrogen    3.388915    3.375  4.0   NaN
+5   CMT06  GPPAllIgnoringNitrogen    9.705867   16.000  5.0   NaN
+6   CMT06  GPPAllIgnoringNitrogen   17.169587    6.000  6.0   NaN
+7   CMT06              MossDeathC   10.570156  178.000  NaN   NaN
+8   CMT06               VegCarbon    2.138998    2.000  0.0  Leaf
+9   CMT06               VegCarbon    4.117513    4.000  0.0  Stem
+10  CMT06               VegCarbon    0.340910    0.297  0.0  Root
+11  CMT06               VegCarbon   42.925257   37.100  1.0  Leaf
+12  CMT06               VegCarbon  280.460292  161.280  1.0  Root
+13  CMT06               VegCarbon    0.156739    8.060  2.0  Leaf
+14  CMT06               VegCarbon   96.316317   11.040  2.0  Root
+15  CMT06               VegCarbon    2.602119    2.000  3.0  Leaf
+16  CMT06               VegCarbon    2.664471    3.200  3.0  Root
+17  CMT06               VegCarbon    2.250932    2.000  4.0  Leaf
+18  CMT06               VegCarbon   22.572059   22.000  5.0  Leaf
+19  CMT06               VegCarbon   22.400614   23.000  6.0  Leaf

--- a/scripts/tests/doctests/doctests_MadsTEMDriver_onlysoiltarget.rst
+++ b/scripts/tests/doctests/doctests_MadsTEMDriver_onlysoiltarget.rst
@@ -1,0 +1,87 @@
+# Testing, developing and describing the interface for MadsTEMDriver.py
+=========================================================================
+
+Testing for using only a soil target. No PFTs, no compartments. This primarily
+makes sure that the interface can handle situation with only soil targets are
+specified.
+
+>>> import yaml
+
+>>> my_yaml_string = """
+... work_dir: /tmp/test_CA
+... site: /work/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10
+... PXx: 0
+... PXy: 0
+... calib_mode: GPPAllIgnoringNitrogen
+... target_names: 
+... - CarbonShallow
+... cmtnum: 6
+... opt_run_setup: --pr-yrs 5 --eq-yrs 10 --sp-yrs 0 --tr-yrs 0 --sc-yrs 0
+... params:
+... - cmax
+... - cmax
+... - cmax
+... pftnums:
+... - 0
+... - 1
+... - 2
+... """
+
+>>> config_dict = yaml.load(my_yaml_string, Loader=yaml.FullLoader)
+
+>>> import drivers.MadsTEMDriver
+
+>>> d = drivers.MadsTEMDriver.MadsTEMDriver(config_dict)
+
+>>> d.set_seed_path('/work/parameters')
+
+>>> d.set_params_from_seed()
+
+>>> d.load_target_data(ref_target_path='/work/calibration/')
+
+>>> d.setup_outputs(d.target_names)
+
+Grab the targets in two differnt formats (flat and labeled) and make sure the
+values line up as expected. 
+
+> Notice here that the `MadsTEMDriver.targets` datastructure includes **all**
+the target data that is included for that CMT (loaded from the
+calibration_targets.py file). In most cases, we are only interested in working
+with a certain subset of the target data - namely those targets that are
+specified in the config yaml. So the `MadsTEMDriver.observed_vec(..)` function
+is provided that can return only the targets of interest. 
+
+>>> import pandas as pd
+
+>>> flat_targets = d.observed_vec(format='flat')
+
+>>> df_targets = pd.DataFrame(d.observed_vec(format='labeled'))
+
+If we check a for a target that is not specified, we should get nothing:
+
+>>> df_targets.loc[df_targets['ctname'] == 'GPPAllIgnoringNitrogen']
+Empty DataFrame
+Columns: [cmtnum, ctname, observed]
+Index: []
+
+>>> flat_targets
+[3358.0]
+
+>>> df_targets
+   cmtnum         ctname  observed
+0       6  CarbonShallow    3358.0
+
+>>> d.params_vec()
+[22.8, 250.6, 65.0]
+
+This makes sense because we haven't run the model yet so there are no outputs.
+
+>>> d.clean()
+
+>>> d.setup_run_dir()
+
+>>> d.run()
+
+>>> d.gather_model_outputs()
+[{'cmt': 'CMT06', 'ctname': 'CarbonShallow', 'value': 3193.170117276907, 'truth': 3358.0}]
+

--- a/scripts/util/metrics.py
+++ b/scripts/util/metrics.py
@@ -105,31 +105,29 @@ def plot_optimization_fit(seed_params=None, ig_params=None, opt_params=None,
   axes[2].set_title("Residuals (model outputs - targets)")
 
   axes[0].plot(seed_params, marker='o', linewidth=0, alpha=0.6, label='seed')
-  axes[1].plot(seed_out, label='seed')
-
   axes[0].plot(ig_params, marker='^', linewidth=0, alpha=0.6, label='ig')
-  axes[1].plot(ig_out, label='ig')
-
   axes[0].plot(opt_params, marker='+', linewidth=0, alpha=0.6, label='opt')
+  axes[0].set_xticklabels(param_labels, rotation=90)
+  axes[0].legend()
+
+  axes[1].plot(seed_out, label='seed')
+  axes[1].plot(ig_out, label='ig')
   axes[1].plot(opt_out, label='opt')
   axes[1].plot(targets, color='red', marker='o', linewidth=0, label='targets')
-
-  axes[0].set_xticklabels(param_labels, rotation=45)
+  axes[1].legend()
+  #axes[1].set_xticklabels([])
   #axes[1].set_xticklabels(out_labels, rotation=45) 
-  axes[2].set_xticklabels(out_labels, rotation=45) 
 
   # Plot the residuals as a bar graph
   axes[2].bar(out_labels, opt_out-targets, align='center', width=.6, 
               color='red', alpha=.75)
-  #axes[1].set_xticklabels([])
+  axes[2].set_xticklabels(out_labels, rotation=90) 
 
   # This handles annoyance with bar plots where the bar is centered, and
   # therfore hangs to the left of zero, and so messes with the auto-scaling...
   for a in (axes[0], axes[1]):
     a.set_xlim(axes[2].get_xlim())
 
-  axes[0].legend()
-  axes[1].legend()
   #axes[2].legend()
 
   plt.tight_layout()

--- a/scripts/util/metrics.py
+++ b/scripts/util/metrics.py
@@ -104,24 +104,27 @@ def plot_optimization_fit(seed_params=None, ig_params=None, opt_params=None,
   axes[1].set_title("Outputs")
   axes[2].set_title("Residuals (model outputs - targets)")
 
-  axes[0].plot(seed_params, marker='o', linewidth=0, alpha=0.6, label='seed')
-  axes[0].plot(ig_params, marker='^', linewidth=0, alpha=0.6, label='ig')
-  axes[0].plot(opt_params, marker='+', linewidth=0, alpha=0.6, label='opt')
-  axes[0].set_xticklabels(param_labels, rotation=90)
+  params_x = np.linspace(0, len(param_labels), len(param_labels))
+
+  axes[0].plot(params_x, seed_params, marker='o', linewidth=0, alpha=0.6, label='seed')
+  axes[0].plot(params_x, ig_params, marker='^', linewidth=0, alpha=0.6, label='ig')
+  axes[0].plot(params_x, opt_params, marker='+', linewidth=0, alpha=0.6, label='opt')
+  axes[0].set_xticks(params_x, param_labels, rotation=90)
   axes[0].legend()
 
-  axes[1].plot(seed_out, label='seed')
-  axes[1].plot(ig_out, label='ig')
-  axes[1].plot(opt_out, label='opt')
-  axes[1].plot(targets, color='red', marker='o', linewidth=0, label='targets')
+  outputs_x = np.linspace(0, len(out_labels), len(out_labels))
+
+  axes[1].plot(outputs_x, seed_out, label='seed')
+  axes[1].plot(outputs_x, ig_out, label='ig')
+  axes[1].plot(outputs_x, opt_out, label='opt')
+  axes[1].plot(outputs_x, targets, color='red', marker='o', linewidth=0, label='targets')
   axes[1].legend()
-  #axes[1].set_xticklabels([])
-  #axes[1].set_xticklabels(out_labels, rotation=45) 
+  axes[1].set_xticks(outputs_x, out_labels, rotation=90)
 
   # Plot the residuals as a bar graph
   axes[2].bar(out_labels, opt_out-targets, align='center', width=.6, 
               color='red', alpha=.75)
-  axes[2].set_xticklabels(out_labels, rotation=90) 
+  axes[2].set_xticks(outputs_x, out_labels, rotation=90) 
 
   # This handles annoyance with bar plots where the bar is centered, and
   # therfore hangs to the left of zero, and so messes with the auto-scaling...

--- a/scripts/util/metrics.py
+++ b/scripts/util/metrics.py
@@ -125,7 +125,7 @@ def plot_optimization_fit(seed_params=None, ig_params=None, opt_params=None,
 
   # This handles annoyance with bar plots where the bar is centered, and
   # therfore hangs to the left of zero, and so messes with the auto-scaling...
-  for a in (axes[0], axes[1]):
+  for a in (axes[1], axes[2]):
     a.set_xlim(axes[2].get_xlim())
 
   #axes[2].legend()


### PR DESCRIPTION
Adds the capability for the observed_vec function to return either a labeled array or flat list of target (observation) values. Turns out that the labeled array was helpful for testing/cross checking the order of the flat list.

Adds tests that go with the new feature.

Fixes bug with indentation of return statement in observed_vec function.

Change AC-MADS-TEM.jl so that it explicitly requests a flat list as the remainder of MADS seems to expect.