### PR TITLE
Implements holding for more regional output variables

### DIFF
--- a/include/OutputHolder.h
+++ b/include/OutputHolder.h
@@ -47,6 +47,7 @@ public:
   std::vector<double> snowthick_for_output;
   std::vector<double> swe_for_output;
   std::vector<double> watertab_for_output;
+  std::vector<double> mossdz_for_output;
 
   //Variables by layer
   std::vector<double> rh_tot_for_output;

--- a/include/OutputHolder.h
+++ b/include/OutputHolder.h
@@ -48,6 +48,8 @@ public:
   std::vector<double> swe_for_output;
   std::vector<double> watertab_for_output;
   std::vector<double> mossdz_for_output;
+  std::vector<double> mossdeathc_for_output;
+  std::vector<double> mossdeathn_for_output;
 
   //Variables by layer
   std::vector<double> rh_tot_for_output;

--- a/include/OutputHolder.h
+++ b/include/OutputHolder.h
@@ -120,6 +120,11 @@ public:
   std::vector<std::array<double, NUM_PFT>> vegc_pft_for_output;
   std::vector<std::array<std::array<double, NUM_PFT>, NUM_PFT_PART>> vegc_for_output; 
 
+  std::vector<double> rm_tot_for_output;
+  std::vector<std::array<double, NUM_PFT_PART>> rm_part_for_output;
+  std::vector<std::array<double, NUM_PFT>> rm_pft_for_output;
+  std::vector<std::array<std::array<double, NUM_PFT>, NUM_PFT_PART>> rm_for_output; 
+
 };
 
 

--- a/include/OutputHolder.h
+++ b/include/OutputHolder.h
@@ -25,6 +25,7 @@ public:
   int months_held;
   int years_held;
 
+  std::vector<int> cmtnum_for_output;
   std::vector<int> ysd_for_output;
 
   std::vector<double> ald_for_output;

--- a/include/OutputHolder.h
+++ b/include/OutputHolder.h
@@ -63,6 +63,9 @@ public:
   std::vector<double> somrawc_tot_for_output;
   std::vector<std::array<double, MAX_SOI_LAY>> somrawc_for_output;
 
+  std::vector<double> avln_tot_for_output;
+  std::vector<std::array<double, MAX_SOI_LAY>> avln_for_output;
+
   std::vector<std::array<double, MAX_SOI_LAY>> layerdepth_for_output;
   std::vector<std::array<double, MAX_SOI_LAY>> layerdz_for_output;
   std::vector<std::array<int, MAX_SOI_LAY>> layertype_for_output;

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -3212,6 +3212,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
   }//end MOSSDEATHN
   map_itr = netcdf_outputs.end();
 
+
   //MOSSDZ
   map_itr = netcdf_outputs.find("MOSSDZ");
   if(map_itr != netcdf_outputs.end()){
@@ -3228,7 +3229,13 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
         }
         currL = currL->nextl;
       }
-      output_nc_3dim(&curr_spec, file_stage_suffix, &mossdz, 1, year, 1);
+
+      outhold.mossdz_for_output.push_back(mossdz);
+
+      if(output_this_timestep){
+        output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.mossdz_for_output[0], 1, year_start_idx, years_to_output);
+        outhold.mossdz_for_output.clear();
+      }
       //The following may never get set to anything useful?
       //y_soil.mossthick;
 

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -3181,11 +3181,21 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //monthly
       if(curr_spec.monthly){
-        output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_v2soi.mossdeathc, 1, month_timestep, 1);
+        outhold.mossdeathc_for_output.push_back(cohort.bdall->m_v2soi.mossdeathc);
+
+        if(output_this_timestep){
+          output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.mossdeathc_for_output[0], 1, month_start_idx, months_to_output);
+          outhold.mossdeathc_for_output.clear();
+        }
       }
       //yearly
       else if(curr_spec.yearly){
-        output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_v2soi.mossdeathc, 1, year, 1);
+        outhold.mossdeathc_for_output.push_back(cohort.bdall->y_v2soi.mossdeathc);
+
+        if(output_this_timestep){
+          output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.mossdeathc_for_output[0], 1, year_start_idx, years_to_output);
+          outhold.mossdeathc_for_output.clear();
+        }
       }
     }//end critical(outputMOSSDEATHC)
   }//end MOSSDEATHC
@@ -3202,11 +3212,21 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //monthly
       if(curr_spec.monthly){
-        output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_v2soi.mossdeathn, 1, month_timestep, 1);
+        outhold.mossdeathn_for_output.push_back(cohort.bdall->m_v2soi.mossdeathn);
+
+        if(output_this_timestep){
+          output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.mossdeathn_for_output[0], 1, month_start_idx, months_to_output);
+          outhold.mossdeathn_for_output.clear();
+        }
       }
       //yearly
       else if(curr_spec.yearly){
-        output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_v2soi.mossdeathn, 1, year, 1);
+        outhold.mossdeathn_for_output.push_back(cohort.bdall->y_v2soi.mossdeathn);
+
+        if(output_this_timestep){
+          output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.mossdeathn_for_output[0], 1, year_start_idx, years_to_output);
+          outhold.mossdeathn_for_output.clear();
+        }
       }
     }//end critical(outputMOSSDEATHN)
   }//end MOSSDEATHN

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -1168,25 +1168,52 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     {
       //By layer
       if(curr_spec.layer){
+        std::array<double, MAX_SOI_LAY> avln_arr{};
+
         //monthly
         if(curr_spec.monthly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_sois.avln[0], MAX_SOI_LAY, month_timestep, 1);
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            avln_arr[il] = cohort.bdall->m_sois.avln[il];
+          }
+          outhold.avln_for_output.push_back(avln_arr);
+
+          if(output_this_timestep){
+            output_nc_4dim(&curr_spec, file_stage_suffix, &outhold.avln_for_output[0], MAX_SOI_LAY, month_start_idx, months_to_output);
+            outhold.avln_for_output.clear();
+          }
         }
         //yearly
         else if(curr_spec.yearly){
-          output_nc_4dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_sois.avln[0], MAX_SOI_LAY, year, 1);
+          for(int il=0; il<MAX_SOI_LAY; il++){
+            avln_arr[il] = cohort.bdall->y_sois.avln[il];
+          }
+          outhold.avln_for_output.push_back(avln_arr);
+
+          if(output_this_timestep){
+            output_nc_4dim(&curr_spec, file_stage_suffix, &outhold.avln_for_output[0], MAX_SOI_LAY, year_start_idx, years_to_output);
+            outhold.avln_for_output.clear();
+          }
         }
       }
       //Total
       else if(!curr_spec.layer){
-
         //monthly
         if(curr_spec.monthly){
-          output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->m_soid.avlnsum, 1, month_timestep, 1);
+          outhold.avln_tot_for_output.push_back(cohort.bdall->m_soid.avlnsum);
+
+          if(output_this_timestep){
+            output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.avln_tot_for_output[0], 1, month_start_idx, months_to_output);
+            outhold.avln_tot_for_output.clear();
+          }
         }
         //yearly
         else if(curr_spec.yearly){
-          output_nc_3dim(&curr_spec, file_stage_suffix, &cohort.bdall->y_soid.avlnsum, 1, year, 1);
+          outhold.avln_tot_for_output.push_back(cohort.bdall->y_soid.avlnsum);
+
+          if(output_this_timestep){
+            output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.avln_tot_for_output[0], 1, year_start_idx, years_to_output);
+            outhold.avln_tot_for_output.clear();
+          }
         }
       }
     }//end critical(outputAVLN)

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -1563,6 +1563,7 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
   }//end BURNVEG2SOILBLWN
   map_itr = netcdf_outputs.end();
 
+
   //Community Type Code (CMT NUMBER)
   map_itr = netcdf_outputs.find("CMTNUM");
   if(map_itr != netcdf_outputs.end()) {
@@ -1570,15 +1571,19 @@ void Runner::output_netCDF(std::map<std::string, OutputSpec> &netcdf_outputs, in
     curr_spec = map_itr->second;
     #pragma omp critical(outputCMTNUM)
     {
-
       int cmtnum;
       cmtnum = temutil::cmtcode2num(this->cohort.chtlu.cmtcode);
 
-      output_nc_3dim(&curr_spec, file_stage_suffix, &cmtnum, 1, year, 1);
+      outhold.cmtnum_for_output.push_back(cmtnum);
 
+      if(output_this_timestep){
+        output_nc_3dim(&curr_spec, file_stage_suffix, &outhold.cmtnum_for_output[0], 1, year_start_idx, years_to_output);
+        outhold.cmtnum_for_output.clear();
+      }
     } //end critical(outputCMTNUM)
   } //end CMTNUM
   map_itr = netcdf_outputs.end();
+
 
   //Standing dead C
   map_itr = netcdf_outputs.find("DEADC");


### PR DESCRIPTION
Implements holding for AVLN, RM, CMTNUM, MOSSDZ, MOSSDEATHC, MOSSDEATHN

Testing was completed by producing TR and SC output files for all combinations available on both master and this branch and comparing them directly.
 ./dvmdostem -l monitor -p 100 -e 100 -s 100 -t 115 -n 85