### PR TITLE
Remove git LFS hashes.

### DIFF
--- a/testing-data/docs/example_experiment_0/ALD_SAMPLE.png
+++ b/testing-data/docs/example_experiment_0/ALD_SAMPLE.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97e33febe35632796aed5c70de764b74635fcb48b3b45a0f8f5b08fcf0d2f15c
-size 40689

--- a/testing-data/docs/example_experiment_0/NEE_SAMPLE.png
+++ b/testing-data/docs/example_experiment_0/NEE_SAMPLE.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4508b47b72a16eb3ba77225cbf9f873038de7554d2d5c67b87500598d9fd0503
-size 46657

--- a/testing-data/docs/example_experiment_0/calibration/calibration_targets.py
+++ b/testing-data/docs/example_experiment_0/calibration/calibration_targets.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d0878a4ec9ad343c09575cb4d45a5784069c037675018672d1e431b5f859d58
-size 34242

--- a/testing-data/docs/example_experiment_0/config/calibration_directives.txt
+++ b/testing-data/docs/example_experiment_0/config/calibration_directives.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae1da6c335b9c25a6024479c9b4c2404240ddbdeea0b9ed55ddca4c84dcdfa15
-size 473

--- a/testing-data/docs/example_experiment_0/config/config.js
+++ b/testing-data/docs/example_experiment_0/config/config.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:049b4adb49a37828386768c6a5623db1d988d80060613321f5efd310af00a83d
-size 2847

--- a/testing-data/docs/example_experiment_0/config/output_spec.csv
+++ b/testing-data/docs/example_experiment_0/config/output_spec.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81b1a4742c955646054444d2b9b5784ff560eef3c6a292421176c8b65b4e6a11
-size 9014

--- a/testing-data/docs/example_experiment_0/output/ALD_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/ALD_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84b4314cf762b9947a0eb7fa5822a7c59759fcf45a0435f4f76e6e1aed8d4ab4
-size 79706

--- a/testing-data/docs/example_experiment_0/output/ALD_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/ALD_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e44b023e94ff5acaa949db6846705349a78f0bcb7f9f64d2d5376113d64abab5
-size 210956

--- a/testing-data/docs/example_experiment_0/output/ALD_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/ALD_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffa6687881f21184510fbd7f34595761a6469de8af0d10cb77e5c1860aecb16d
-size 103946

--- a/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e53dbf336b0b1bf584eeecd0dc946d660c4d5f5cf4a3fd16df020798c1b7c5e
-size 45707

--- a/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a52f10c1cc850af405d1dfde1b22a377ea1a64f73edbc7ad31492e9482b066c2
-size 110891

--- a/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/CMTNUM_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38a75eba4c2ee184d723d000bf92941290fb2a1f0ad559ffb6977c55afde13ec
-size 57947

--- a/testing-data/docs/example_experiment_0/output/DEEPC_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPC_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b34ebf1911933c25a43d06c69833a746e13ab006360a92371ef52ca0762daf62
-size 79731

--- a/testing-data/docs/example_experiment_0/output/DEEPC_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPC_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcccac46b500d3037488ead332540d332a8396cc7d4e7b3e03b9d09eafc6e685
-size 210950

--- a/testing-data/docs/example_experiment_0/output/DEEPC_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPC_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:666b7e0ac596b255815337f6efff1d3be48040075d5ab751a9583536721eefa9
-size 103971

--- a/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdfb6e9f4974293758cb20462c0a286348ace41d23aea45e46cfa1ba1fbd88e9
-size 79745

--- a/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f50fef52b0f91fd940325b294c35f193d2289c120b819eb6134e78492d95ff60
-size 210967

--- a/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/DEEPDZ_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:152ac87259ad056a22251aa7deddbff09abafc157fc522173435a70c21032a26
-size 103985

--- a/testing-data/docs/example_experiment_0/output/GPP_monthly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/GPP_monthly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc92983616538c70013e56336b37db76f2160f417a8be6e6755b1b1eae14f947
-size 8179891

--- a/testing-data/docs/example_experiment_0/output/GPP_monthly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/GPP_monthly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fd54fb01fabfd39e30442d926bd515f6c83ad7cf13a3113511ec359607654df
-size 24011654

--- a/testing-data/docs/example_experiment_0/output/GPP_monthly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/GPP_monthly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b52f2cca458eab718c27bd1a8ef19f8245d076baed07e96155f55c29cd03ddb5
-size 11062771

--- a/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddacba2c3cbcb905c858dee5f2bedc86d99d2013b2affae782c383188f3f4f8c
-size 1508463

--- a/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44a06281c3ddd2e19ebb89aaa407fa341bd89fb0fbf7c042f0dd77d09f0332c8
-size 4411679

--- a/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDEPTH_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a1f905f9c782f70268effb125eb737c319717a18d632e955805f37e99ef0202
-size 2036703

--- a/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d149737459a55eb7c73324f8d4492a4bf385565b82b0416a0739578e39a95a1c
-size 1508451

--- a/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:918ea028cc05f28f4852a49fe49c5b7c1249453b436b3b3d195e47a82d7994de
-size 4411666

--- a/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERDZ_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86f97df071f22128d2fa3be36762e4873f465a8e35afaf266f0ad0e68bdaa531
-size 2036691

--- a/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2c0c24b19786e2ccafa79a9c9871d703b339670cea61265271272ad35b10936
-size 760490

--- a/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:442766a961835f24a60e9e9a18c6ea89b5419dd1614612600a07474623c26333
-size 2211683

--- a/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/LAYERTYPE_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d7c457d032aea26e27455bf0b6316b6cd4084268a98fbc20edd335bc3173d2b
-size 1024730

--- a/testing-data/docs/example_experiment_0/output/MINEC_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/MINEC_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43018d96b4f88043827e1bc963b55a6d80c5a2dcfcbd9d2415eb98b43a48f502
-size 79729

--- a/testing-data/docs/example_experiment_0/output/MINEC_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/MINEC_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b4735bc629b66606cf9063ac5319882d683c302f94160e1140843be60b37a64
-size 210948

--- a/testing-data/docs/example_experiment_0/output/MINEC_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/MINEC_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80f25a2bbad06e64354434b8f367e40c3742ed231cbad9bb42780cba291eada9
-size 103969

--- a/testing-data/docs/example_experiment_0/output/RG_monthly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/RG_monthly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d5325b230932ccf7fafac601cc91627a85dbf5ad86b0724eb8d2690d7815b0a
-size 835190

--- a/testing-data/docs/example_experiment_0/output/RG_monthly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/RG_monthly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e71c1a3831c9d8986ee3d184275de701140a1e4effcce55ea573c6dd999b95c1
-size 2410950

--- a/testing-data/docs/example_experiment_0/output/RG_monthly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/RG_monthly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:471f02a99ae2a3f560200ef4e40333b8ef0687e34e63cdae6fcf336440303e98
-size 1126070

--- a/testing-data/docs/example_experiment_0/output/RH_monthly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/RH_monthly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afac96e2049529c241391030bdf4ac73db4aa7ac4bd0078ba34a1e39624b9d5a
-size 835197

--- a/testing-data/docs/example_experiment_0/output/RH_monthly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/RH_monthly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:626a2edbc946d8648a143dd944731c6d6f2711feeaa3ab00feaa76d9185eb560
-size 2410957

--- a/testing-data/docs/example_experiment_0/output/RH_monthly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/RH_monthly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:773426a57726edb48cc5742d30894bf5ed3615e8989da60f5a17448215e80218
-size 1126077

--- a/testing-data/docs/example_experiment_0/output/RM_monthly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/RM_monthly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14533f38849cf50917664de717f970cd7200a686c94f2877344e7b48e8fbad41
-size 835195

--- a/testing-data/docs/example_experiment_0/output/RM_monthly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/RM_monthly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94dbd64e4917fc57c60d6c84c58cc44420b64eaa0011a4a2dc528457b40026c9
-size 2410955

--- a/testing-data/docs/example_experiment_0/output/RM_monthly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/RM_monthly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8952d6ef4b55e06ee7bf97ac3ce2f8b8334f264a3252763725ae2e5bd044a147
-size 1126075

--- a/testing-data/docs/example_experiment_0/output/SHLWC_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWC_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab05ef2a8817773efbdf47e71f609ce6d374beb061d082aa4a2b86ca1881af38
-size 79729

--- a/testing-data/docs/example_experiment_0/output/SHLWC_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWC_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33d3c77c22d864225c910f33ca1607fb2380a2475edffe1f66cf259e9e5b96df
-size 210948

--- a/testing-data/docs/example_experiment_0/output/SHLWC_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWC_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f6a5c99b9f451a8ece104a7ce491c28eee9447676538c8e46a887a04b43614a
-size 103969

--- a/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:464c2e8bbb7d6fe89342880deeb4bed38e6a54ed0d9d05e00bd5bfc27e583263
-size 79743

--- a/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71ada031453cd0bcbab88befacfab6bd6fe3766fa9e9e0ced00a4a64a80088d0
-size 210965

--- a/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/SHLWDZ_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8173523eadd913efecd536fbfec803b1fdcaf1d5c2a6d5908ac8b9c59b849a69
-size 103983

--- a/testing-data/docs/example_experiment_0/output/TLAYER_monthly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/TLAYER_monthly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1f2f1e6275b33f9283a328da3e7d4325e969b46e4bf1b9baddfee4f941bc219
-size 17971939

--- a/testing-data/docs/example_experiment_0/output/TLAYER_monthly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/TLAYER_monthly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fa98ba873261d235061e4bf176ee05561ef2c706452a529320062af734eb4f1
-size 52811674

--- a/testing-data/docs/example_experiment_0/output/TLAYER_monthly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/TLAYER_monthly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:651d5e49ce6b0aad9b58a969263fa931e5a5cc99506ceb158020b8c9459c16ce
-size 24310819

--- a/testing-data/docs/example_experiment_0/output/VEGC_yearly_sc.nc
+++ b/testing-data/docs/example_experiment_0/output/VEGC_yearly_sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4eac6f120c7e22ab0303d929627647559e5ba69835a67cc482c087285fa9999a
-size 79706

--- a/testing-data/docs/example_experiment_0/output/VEGC_yearly_sp.nc
+++ b/testing-data/docs/example_experiment_0/output/VEGC_yearly_sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59a24a438dd737c64a32c3f107f4e631e39a95f1251654afcf4be104bb292946
-size 210954

--- a/testing-data/docs/example_experiment_0/output/VEGC_yearly_tr.nc
+++ b/testing-data/docs/example_experiment_0/output/VEGC_yearly_tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fedd1ef5350be7cff6091c2d16a380c25cc065cb7a1bd464547d26c2e3ab342
-size 103946

--- a/testing-data/docs/example_experiment_0/output/restart-eq.nc
+++ b/testing-data/docs/example_experiment_0/output/restart-eq.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2fb6e159c4184e49ae020e2a836dd0b88b9da079684a772a7a36bd8f5d51be9
-size 1088428

--- a/testing-data/docs/example_experiment_0/output/restart-pr.nc
+++ b/testing-data/docs/example_experiment_0/output/restart-pr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f729d798b5145bdd212f19a628d43b6bec162c4c905272950bc302a7b0f7d19
-size 1088428

--- a/testing-data/docs/example_experiment_0/output/restart-sc.nc
+++ b/testing-data/docs/example_experiment_0/output/restart-sc.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c0d6a359e8cd02528ad73961a51d00d75d345114aa682df45cef947ed080d34
-size 1088428

--- a/testing-data/docs/example_experiment_0/output/restart-sp.nc
+++ b/testing-data/docs/example_experiment_0/output/restart-sp.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a733c25d494a1971898d015104e4285c6ab9ca103d7e86a25ef4f5b55d1fb33
-size 1088428

--- a/testing-data/docs/example_experiment_0/output/restart-tr.nc
+++ b/testing-data/docs/example_experiment_0/output/restart-tr.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd9c2de2a423decf1a71b6e7da8b338888060f3a1b9b0e1f43cbb22bd761af2c
-size 1088428

--- a/testing-data/docs/example_experiment_0/output/run_status.nc
+++ b/testing-data/docs/example_experiment_0/output/run_status.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be4dd278576e278ca53545e58941c1c20a7aad50add590c3c8ab838fa6a84b55
-size 1040

--- a/testing-data/docs/example_experiment_0/parameters/cmt_bgcsoil.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_bgcsoil.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef73cc3af82489739290608fe2ba52386f3558fd2751715a4f6b1bd9ee833348
-size 9611

--- a/testing-data/docs/example_experiment_0/parameters/cmt_bgcvegetation.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_bgcvegetation.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82519c8b36a29696b687f3fe6b5a76b29448d83a35611a994b6f237e1ec1325c
-size 62324

--- a/testing-data/docs/example_experiment_0/parameters/cmt_calparbgc.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_calparbgc.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74d33492087a68cdfd69b90a1052d662db50966ca20ecdaa56ff62e21ffa0717
-size 31910

--- a/testing-data/docs/example_experiment_0/parameters/cmt_dimground.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_dimground.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e64363d83dd64b9ecd973920d042f098e0f2b0b2acdf322937142acff2a0e8c
-size 12663

--- a/testing-data/docs/example_experiment_0/parameters/cmt_dimvegetation.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_dimvegetation.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c18d60ca88b0760e47124bfdcc31887dae30a212deb72f859ba822c45d40d7ee
-size 84893

--- a/testing-data/docs/example_experiment_0/parameters/cmt_envcanopy.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_envcanopy.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af9824538496f49ccb91d038dc3005b45aa00b44cb7af58ec78e10c514791810
-size 28924

--- a/testing-data/docs/example_experiment_0/parameters/cmt_envground.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_envground.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26fff64e57024c9fcf8c76a4d297ff604584433d3bc5630651f5dadcf8d948d3
-size 40447

--- a/testing-data/docs/example_experiment_0/parameters/cmt_firepar.txt
+++ b/testing-data/docs/example_experiment_0/parameters/cmt_firepar.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:707c8c79ac482032744772757556b22868ab3e4075218a528afef5b3eb4f67bb
-size 39068

--- a/testing-data/docs/example_experiment_0/run-mask.nc
+++ b/testing-data/docs/example_experiment_0/run-mask.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8b763dfa993b356f3aa4b67fbf667089c9d86056df1c6a8aac6c6bafcf58659
-size 14793

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/co2.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/co2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f96740058a424d0b0bf0204eee849258c03c5422deb8c524255b01ca05127445
-size 18576

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/drainage.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/drainage.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b75a56e385a89b5802429e9fcf618cafd1963610743994c90f863165817581cb
-size 14333

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/fri-fire.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/fri-fire.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f88954fdc5cc072c842cadbf0b8de75885945212d9388c49562b177d5f92fe8
-size 20320

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/historic-climate.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/historic-climate.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e8eee3aabc2a3f692b99b94c8bba2e39fa99c16ab4958e91079a8085aaf1795
-size 2571417

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/historic-explicit-fire.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/historic-explicit-fire.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91d1b1900f8f77c24045bc72bde71e7d60dd3f4c209b01948eb658031e41e717
-size 248048

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/notes.txt
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/notes.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b06be473fe092e5749c0b7e1fe46eb846144e1cea7ad4c4710aa2b163c5b59f9
-size 316

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/original-vegetation.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/original-vegetation.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23e51e415869cbb419b4d9665d7f179bda5fc6a17289aaf9028307afb4b885bb
-size 14487

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-climate.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-climate.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dae17a6788afd65d917a3bfd8994722fab9c108a119dad08eccbbae832086118
-size 1904757

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-co2.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-co2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6b4af34c015993c62925eb563576afd1cccf28fdf617adb91c27bfad2a2ca0f
-size 15168

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-explicit-fire.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/projected-explicit-fire.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8de9fae777c6072bc905ef00c7432d4f7f75b9159c1a7944223fc50e9038e162
-size 200048

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/run-mask.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/run-mask.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eede34cb46e1f40d65d99490d4d4a7c5eb8d9d0f86dd903fdccd3953a8471604
-size 14793

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/soil-texture.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/soil-texture.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1242196e5e2e4c785ed25c1e81e67011d4ecdf483cf93467cbbd2281a7f4b50
-size 19189

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/topo.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/topo.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aaa0414a6bae7a11b5d528168f19ee0b251a845911fe56025dae717044c1d2d0
-size 18183

--- a/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/vegetation.nc
+++ b/testing-data/inputs/cru-ts40_ar5_rcp85_ncar-ccsm4_IMNAVIAT_CREEK_10x10/vegetation.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23e51e415869cbb419b4d9665d7f179bda5fc6a17289aaf9028307afb4b885bb
-size 14487

--- a/testing-data/parameters/single_cmt/cmt_bgcsoil.txt
+++ b/testing-data/parameters/single_cmt/cmt_bgcsoil.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b31b69fe8a2b9dff8f460c2ac30baefe25ab6b9e697d3b06d6f0a2a3affa493
-size 783

--- a/testing-data/parameters/single_cmt/cmt_bgcvegetation.txt
+++ b/testing-data/parameters/single_cmt/cmt_bgcvegetation.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8fd6c0681fd0eda54a0c402ad53b83ae2b01bb7fd0adc0b1b3eddd0db396562
-size 3822

--- a/testing-data/parameters/single_cmt/cmt_calparbgc.txt
+++ b/testing-data/parameters/single_cmt/cmt_calparbgc.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00b91443b3eef491eed9f52fbbc4876ebfc8a842f4f37bd1667f1456d9d886d9
-size 2431

--- a/testing-data/parameters/single_cmt/cmt_dimground.txt
+++ b/testing-data/parameters/single_cmt/cmt_dimground.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab9314c23e6dd0e634b6bf6d641a576f665b35c57491a29850fd3b3969eadc27
-size 1013

--- a/testing-data/parameters/single_cmt/cmt_dimvegetation.txt
+++ b/testing-data/parameters/single_cmt/cmt_dimvegetation.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b96156512e0d87ea0f11cbffe78ab0d7fd760b5c6f67f57e3f1cc30d5cd4dd5
-size 5857

--- a/testing-data/parameters/single_cmt/cmt_envcanopy.txt
+++ b/testing-data/parameters/single_cmt/cmt_envcanopy.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:455d5003baa0976cef946a34cffbb1abb3a85ada94cbbc6ac9cc0a157a0e5bc9
-size 1868

--- a/testing-data/parameters/single_cmt/cmt_envground.txt
+++ b/testing-data/parameters/single_cmt/cmt_envground.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41383817ea8fa18cf7d8cbb9454abfd677c92da480c861b041d480a4422a1544
-size 3159

--- a/testing-data/parameters/single_cmt/cmt_firepar.txt
+++ b/testing-data/parameters/single_cmt/cmt_firepar.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b5fcb8adbca8436562f4b46eb54a33fc800ab6a900eb3d002eb6459d2f2f198
-size 3003


### PR DESCRIPTION
Git LFS usage quotas are too low and the prices too expensive for this project. Removing hashes (the hashes are the small files that are actually tracked) from the project so that users are not getting errors when cloning and checking out. Users may still get errors if they try to checkout a point in the history tree with the hash files tracked. This is surmountable by setting an environment variable telling git-lfs not to run the smudge filter, e.g.:

    $ GIT_LFS_SKIP_SMUDGE=1 git checkout <SHA>

This means that for now the testing data is not available with the project. The best way to get the data, which is necessary for building the documentation, will be to contact a maintainer. In the future this data will be stored in a publicly available cloud bucket or similarly accessible location.