### PR TITLE
Ice liq new splitting

### DIFF
--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -1565,7 +1565,7 @@ void Ground::splitOneSoilLayer(SoilLayer*usl, SoilLayer* lsl,
 
   //If either are partially or completely frozen based on frozen
   // fraction, not state
-  if(f1>0. or f2>0.){
+  if(f1>0.0 or f2>0.0){
     double lower_frozen_ratio = lower_frozen_dz/total_frozen_dz;
     ice2 = lower_frozen_ratio * totice;
     ice1 = totice - ice2;
@@ -1580,18 +1580,17 @@ void Ground::splitOneSoilLayer(SoilLayer*usl, SoilLayer* lsl,
 
   //Redistributing liquid water
   double liq1, liq2;
-  f1=1.0-usl->frozenfrac;
-  f2=1.0-lsl->frozenfrac;
+  double unf1 = 1.0 - usl->frozenfrac;
+  double unf2 = 1.0 - lsl->frozenfrac;
 
-  if (f2<=0.) {
-    liq1 = totliq;
-    liq2 = 0.;
-  } else if (f1==f2) {
-    liq1 = (1.0-lslfrac)*totliq;
-    liq2 = lslfrac*totliq;
-  } else  {
-    liq2 = (totwat*f1-totliq)/(f1/f2-1.0);
+  //if either are partially or completely unfrozen
+  if(unf1>0.0 or unf2>0.0){
+    liq2 = lslfrac * totliq;
     liq1 = totliq - liq2;
+  }
+  else{ //if both are completely frozen
+    liq2 = 0;
+    liq1 = totliq; //Should be 0, but setting to totliq in case
   }
 
   usl->liq = fmin(liq1, usl->maxliq);
@@ -1601,31 +1600,31 @@ void Ground::splitOneSoilLayer(SoilLayer*usl, SoilLayer* lsl,
   //  not updated
   //first, assign 'lsl' C with original 'usl', then update it using actual
   //  thickness and depth
-  lsl->rawc =usl->rawc;
-  lsl->soma =usl->soma;
-  lsl->sompr=usl->sompr;
-  lsl->somcr=usl->somcr;
-  lsl->orgn =usl->orgn;
-  lsl->avln =usl->avln;
+  lsl->rawc = usl->rawc;
+  lsl->soma = usl->soma;
+  lsl->sompr = usl->sompr;
+  lsl->somcr = usl->somcr;
+  lsl->orgn = usl->orgn;
+  lsl->avln = usl->avln;
 
   if (usl->isOrganic) {
     double pldtop = updeptop + usl->dz;   //usl->dz has been updated above
     double pldbot = pldtop + lsl->dz;
     getOslCarbon5Thickness(lsl, pldtop, pldbot);
   } else {
-    lsl->rawc  *= lslfrac;
-    lsl->soma  *= lslfrac;
+    lsl->rawc *= lslfrac;
+    lsl->soma *= lslfrac;
     lsl->sompr *= lslfrac;
     lsl->somcr *= lslfrac;
-    lsl->orgn  *= lslfrac;
-    lsl->avln  *= lslfrac;
+    lsl->orgn *= lslfrac;
+    lsl->avln *= lslfrac;
   }
 
   // then update C for new 'usl'
   usl->rawc -= lsl->rawc;
   usl->soma -= lsl->soma;
-  usl->sompr-= lsl->sompr;
-  usl->somcr-= lsl->somcr;
+  usl->sompr -= lsl->sompr;
+  usl->somcr -= lsl->somcr;
   usl->orgn -= lsl->orgn;
   usl->avln -= lsl->avln;
 };

--- a/src/Ground.cpp
+++ b/src/Ground.cpp
@@ -1570,9 +1570,12 @@ void Ground::splitOneSoilLayer(SoilLayer*usl, SoilLayer* lsl,
     ice2 = lower_frozen_ratio * totice;
     ice1 = totice - ice2;
   }
-  else{
+  else{ //Both layers are completely thawed
+    if(totice > 0.0){
+      BOOST_LOG_SEV(glg, warn) << "Positive ice content when both layers are unfrozen";
+    }
     ice2 = 0;
-    ice1 = totice; //Should be 0, but setting to totice just in case
+    ice1 = 0;
   }
 
   usl->ice = fmin(ice1, usl->maxice);
@@ -1583,9 +1586,14 @@ void Ground::splitOneSoilLayer(SoilLayer*usl, SoilLayer* lsl,
   double unf1 = 1.0 - usl->frozenfrac;
   double unf2 = 1.0 - lsl->frozenfrac;
 
+  double upper_unfrozen_dz = unf1 * usl->dz;
+  double lower_unfrozen_dz = unf2 * lsl->dz;
+  double total_unfrozen_dz = upper_unfrozen_dz + lower_unfrozen_dz;
+
   //if either are partially or completely unfrozen
   if(unf1>0.0 or unf2>0.0){
-    liq2 = lslfrac * totliq;
+    double lower_unfrozen_ratio = lower_unfrozen_dz/total_unfrozen_dz;
+    liq2 = lower_unfrozen_ratio * totliq;
     liq1 = totliq - liq2;
   }
   else{ //if both are completely frozen


### PR DESCRIPTION
This modifies the ice and liquid redistribution on layer split
to avoid an error that occurs when the frozen fractions of
the two new layers are very close to each other.