### PR TITLE
Enforce capitalization of proper nouns and acronyms in bib file.

### DIFF
--- a/docs_src/sphinx/source/bibliography.bib
+++ b/docs_src/sphinx/source/bibliography.bib
@@ -12,7 +12,7 @@
   issue        = 2
 }
 @article{balshi2009assessing,
-  title        = {Assessing the response of area burned to changing climate in western boreal North America using a Multivariate Adaptive Regression Splines (MARS) approach},
+  title        = {Assessing the response of area burned to changing climate in western boreal {N}orth {A}merica using a {M}ultivariate {A}daptive {R}egression Splines ({MARS}) approach},
   author       = {Michael S. Balshi and A. David McGuire and Paul Duffy and Mike Flannigan and John Walsh and Jerry Melillo},
   year         = 2009,
   journal      = {Global Change Biology},
@@ -25,7 +25,7 @@
   keywords     = {Boreal forest,Climate change,Fire,Future area burned,Multivariate Adaptive Regression Splines}
 }
 @article{balshi2009vulnerability,
-  title        = {Vulnerability of carbon storage in North American boreal forests to wildfires during the 21st century},
+  title        = {Vulnerability of carbon storage in {N}orth {A}merican boreal forests to wildfires during the 21st century},
   author       = {Michael S. Balshi and A. D. Mcguire and P. Duffy and M. Flannigan and D. W. Kicklighter and J. Melillo},
   year         = 2009,
   journal      = {Global Change Biology},
@@ -65,7 +65,7 @@
 }
 
 @article{decker2009impact,
-  title        = {Impact of Modified Richards Equation on Global Soil Moisture Simulation in the Community Land Model (CLM3.5)},
+  title        = {Impact of Modified {R}ichards Equation on Global Soil Moisture Simulation in the {C}ommunity {L}and {M}odel ({CLM}3.5)},
   author       = {Mark Decker and Xubin Zeng},
   year         = 2009,
   month        = 3,
@@ -78,7 +78,7 @@
   issue        = 3
 }
 @misc{eaton2011netcdf,
-  title        = {NetCDF Climate and Forecast (CF) Metadata Conventions},
+  title        = {NetCDF Climate and Forecast ({CF}) Metadata Conventions},
   author       = {B. Eaton and J. Gregory and B. Drach and K. Taylor and S. Hankin and J. Caron and R. Signell and P. Bentley and G. Rappa and H. Höck and A. Pamment and M. Juckes},
   year         = 2011,
   url          = {https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html}
@@ -98,7 +98,7 @@
   keywords     = {Carbon sequestration,Climate change,Growing season,Permafrost,Productivity,Respiration,Snow cover,Terrestrial ecosystem model}
 }
 @article{euskirchen2009changes,
-  title        = {Changes in vegetation in northern Alaska under scenarios of climate change, 2003-2100: implications for climate feedbacks},
+  title        = {Changes in vegetation in northern {A}laska under scenarios of climate change, 2003-2100: implications for climate feedbacks},
   author       = {E. S. Euskirchen and A. D. Mcguire and F. S. Chapin and S. Yi and C. C. Thompson},
   year         = 2009,
   month        = 7,
@@ -113,7 +113,7 @@
   pmid         = 19544741
 }
 @article{euskirchen2014changes,
-  title        = {Changes in the structure and function of northern Alaskan ecosystems when considering variable leaf-out times across groupings of species in a dynamic vegetation model},
+  title        = {Changes in the structure and function of northern {A}laskan ecosystems when considering variable leaf-out times across groupings of species in a dynamic vegetation model},
   author       = {Eugénie S. Euskirchen and Tobey B. Carman and A. David Mcguire},
   year         = 2014,
   month        = 3,
@@ -141,7 +141,7 @@
   issue        = 8
 }
 @article{euskirchen2022assessing,
-  title        = {Assessing dynamic vegetation model parameter uncertainty across Alaskan arctic tundra plant communities},
+  title        = {Assessing dynamic vegetation model parameter uncertainty across {A}laskan arctic tundra plant communities},
   author       = {Eugénie S. Euskirchen and Shawn P. Serbin and Tobey B. Carman and Jennifer M. Fraterrigo and Hélène Genet and Colleen M. Iversen and Verity Salmon and A. David McGuire},
   year         = 2022,
   month        = 3,
@@ -156,7 +156,7 @@
   pmid         = 34787932
 }
 @article{fan2013response,
-  title        = {The response of soil organic carbon of a rich fen peatland in interior Alaska to projected climate change},
+  title        = {The response of soil organic carbon of a rich fen peatland in interior {A}laska to projected climate change},
   author       = {Zhaosheng Fan and Anthony David Mcguire and Merritt R. Turetsky and Jennifer W. Harden and James Michael Waddington and Evan S. Kane},
   year         = 2013,
   month        = 2,
@@ -171,7 +171,7 @@
   pmid         = 23504796
 }
 @article{genet2013modeling,
-  title        = {Modeling the effects of fire severity and climate warming on active layer thickness and soil carbon storage of black spruce forests across the landscape in interior Alaska},
+  title        = {Modeling the effects of fire severity and climate warming on active layer thickness and soil carbon storage of black spruce forests across the landscape in interior {A}laska},
   author       = {H. Genet and A. D. McGuire and K. Barrett and A. Breen and E. S. Euskirchen and J. F. Johnstone and E. S. Kasischke and A. M. Melvin and A. Bennett and M. C. Mack and T. S. Rupp and A. E.G. Schuur and M. R. Turetsky and F. Yuan},
   year         = 2013,
   journal      = {Environmental Research Letters},
@@ -184,7 +184,7 @@
   keywords     = {boreal forest,ecosystem model,fire severity,organic layer,permafrost,soil carbon}
 }
 @article{genet2018role,
-  title        = {The role of driving factors in historical and projected carbon dynamics of upland ecosystems in Alaska:},
+  title        = {The role of driving factors in historical and projected carbon dynamics of upland ecosystems in {A}laska},
   author       = {Hélène Genet and Yujie He and Zhou Lyu and A. David McGuire and Qianlai Zhuang and Joy Clein and David D'Amore and Alec Bennett and Amy Breen and Frances Biles and Eugénie S. Euskirchen and Kristofer Johnson and Tom Kurkowski and Svetlana Kushch Schroder and Neal Pastick and T. Scott Rupp and Bruce Wylie and Yujin Zhang and Xiaoping Zhou and Zhiliang Zhu},
   year         = 2018,
   month        = 1,
@@ -200,7 +200,7 @@
   pmid         = 29044791
 }
 @article{hayes2011anorthern,
-  title        = {Is the northern high-latitude land-based CO 2 sink weakening?},
+  title        = {Is the northern high-latitude land-based {CO}2 sink weakening?},
   author       = {D. J. Hayes and A. D. McGuire and D. W. Kicklighter and K. R. Gurney and T. J. Burnside and J. M. Melillo},
   year         = 2011,
   journal      = {Global Biogeochemical Cycles},
@@ -211,7 +211,7 @@
   issue        = 3
 }
 @article{hayes2011effects,
-  title        = {The effects of land cover and land use change on the contemporary carbon balance of the arctic and boreal terrestrial ecosystems of Northern Eurasia},
+  title        = {The effects of land cover and land use change on the contemporary carbon balance of the arctic and boreal terrestrial ecosystems of {N}orthern {E}urasia},
   author       = {Daniel J. Hayes and A. David McGuire and David W. Kicklighter and Todd J. Burnside and Jerry M. Melillo},
   year         = 2011,
   journal      = {Eurasian Arctic Land Cover and Land Use in a Changing Climate},
@@ -222,13 +222,13 @@
   abstract     = {Recent changes in climate, disturbance regimes and land use and management systems in Northern Eurasia have the potential to disrupt the terrestrial sink of atmospheric CO2 in a way that accelerates global climate change. To determine the recent trends in the carbon balance of the arctic and boreal ecosystems of this region, we performed a retrospective analysis of terrestrial carbon dynamics across northern Eurasia over a recent 10-year period using a terrestrial biogeochemical process model. The results of the simulations suggest a shift in direction of the net flux from the terrestrial sink of earlier decades to a net source on the order of 45 Tg C year-1 between 1997 and 2006. The simulation framework and subsequent analyses presented in this study attribute this shift to a large loss of carbon from boreal forest ecosystems, which experienced a trend of decreasing precipitation and a large area burned during this time period. © 2011 Springer Science+Business Media B.V.}
 }
 @article{jafarovINPREP2024,
-  title        = {Estimation of above- and below-ground ecosystem parameters for the DVM-DOS-TEM model using MADS: a synthetic case study},
+  title        = {Estimation of above- and below-ground ecosystem parameters for the {DVM}-{DOS}-{TEM} model using {MADS}: a synthetic case study},
   author       = {Elchin E. Jafarov and Hélène Genet Genet and Velimir V. (Monty) Vesselinov and Valeria Briones and Aiza Kabeer and Andrew L. Mullen and Benjamin Maglio and Tobey Carman and Ruth Rutter and Joy Clein and Chu-Chun Chang and Dogukan Teber and Trevor Smith and Joshua Rady and Christina Schädel and Jennifer D. Watts and Brendan M. Rogers and Susan Natali},
   journal      = {Manuscript submitted for publication},
   year         = 2024,
 }
 @article{jafarov2013effects,
-  title        = {The effects of fire on the thermal stability of permafrost in lowland and upland black spruce forests of interior Alaska in a changing climate},
+  title        = {The effects of fire on the thermal stability of permafrost in lowland and upland black spruce forests of interior {A}laska in a changing climate},
   author       = {E. E. Jafarov and V. E. Romanovsky and H. Genet and A. D. McGuire and S. S. Marchenko},
   year         = 2013,
   journal      = {Environmental Research Letters},
@@ -239,7 +239,7 @@
   issue        = 3
 }
 @article{johnstone2010changes,
-  title        = {Changes in fire regime break the legacy lock on successional trajectories in Alaskan boreal forest},
+  title        = {Changes in fire regime break the legacy lock on successional trajectories in {A}laskan boreal forest},
   author       = {Jill F. Johnstone and Teresa N. Hollingsworth and F. Stuart Chapin and Michelle C. Mack},
   year         = 2010,
   journal      = {Global Change Biology},
@@ -250,7 +250,7 @@
   issue        = 4
 }
 @misc{jordan1991onedimensional,
-  title        = {A One-dimensional temperature model for a snow cover : technical documentation for SNTHERM.89},
+  title        = {A One-dimensional temperature model for a snow cover: technical documentation for {SNTHERM}.89},
   author       = {Rachel E. Jordan},
   year         = 1991,
   journal      = {Special Report 91-16},
@@ -273,7 +273,7 @@
   issue        = 1
 }
 @article{lara2015polygonal,
-  title        = {Polygonal tundra geomorphological change in response to warming alters future CO2 and CH4 flux on the Barrow Peninsula},
+  title        = {Polygonal tundra geomorphological change in response to warming alters future {CO}2 and {CH}4 flux on the {B}arrow {P}eninsula},
   author       = {Mark J. Lara and A. David Mcguire and Eugenie S. Euskirchen and Craig E. Tweedie and Kenneth M. Hinkel and Alexei N. Skurikhin and Vladimir E. Romanovsky and Guido Grosse and W. Robert Bolton and Helene Genet},
   year         = 2015,
   month        = 4,
@@ -301,7 +301,7 @@
   issue        = {1-4}
 }
 @article{lyu2018role,
-  title        = {The role of environmental driving factors in historical and projected carbon dynamics of wetland ecosystems in Alaska},
+  title        = {The role of environmental driving factors in historical and projected carbon dynamics of wetland ecosystems in {A}laska},
   author       = {Zhou Lyu and Hélène Genet and Yujie He and Qianlai Zhuang and A. David McGuire and Alec Bennett and Amy Breen and Joy Clein and Eugénie S. Euskirchen and Kristofer Johnson and Tom Kurkowski and Neal J. Pastick and T. Scott Rupp and Bruce K. Wylie and Zhiliang Zhu},
   year         = 2018,
   month        = 9,
@@ -317,7 +317,7 @@
   pmid         = 29808543
 }
 @article{mcguire1992interactions,
-  title        = {Interactions between carbon and nitrogen dynamics in estimating net primary productivity for potential vegetation in North America},
+  title        = {Interactions between carbon and nitrogen dynamics in estimating net primary productivity for potential vegetation in {N}orth {A}merica},
   author       = {A. D. McGuire and J. M. Melillo and L. A. Joyce and D. W. Kicklighter and A. L. Grace and B. Moore and C. J. Vorosmarty},
   year         = 1992,
   journal      = {Global Biogeochemical Cycles},
@@ -329,7 +329,7 @@
   issue        = 2
 }
 @article{mcguire2018assessing,
-  title        = {Assessing historical and projected carbon balance of Alaska: A synthesis of results and policy/management implications},
+  title        = {Assessing historical and projected carbon balance of {A}laska: A synthesis of results and policy/management implications},
   author       = {A. David McGuire and Hélène Genet and Zhou Lyu and Neal Pastick and Sarah Stackpoole and Richard Birdsey and David D'Amore and Yujie He and T. Scott Rupp and Robert Striegl and Bruce K. Wylie and Xiaoping Zhou and Qianlai Zhuang and Zhiliang Zhu},
   year         = 2018,
   month        = 9,
@@ -345,7 +345,7 @@
   pmid         = 29923353
 }
 @article{merkel2014docker,
-  title        = {Docker: lightweight Linux containers for consistent development and deployment},
+  title        = {Docker: lightweight {L}inux containers for consistent development and deployment},
   author       = {Dirk Merkel},
   year         = 2014,
   month        = 3,
@@ -358,7 +358,7 @@
   issue        = 239
 }
 @article{niu2005simple,
-  title        = {A simple TOPMODEL-based runoff parameterization (SIMTOP) for use in global climate models},
+  title        = {A simple {TOPMODEL}-based runoff parameterization ({SIMTOP}) for use in global climate models},
   author       = {Guo Yue Niu and Zong Liang Yang and Robert E. Dickinson and Lindsey E. Gulden},
   year         = 2005,
   month        = 11,
@@ -372,7 +372,7 @@
   issue        = 21
 }
 @article{raich1991potential,
-  title        = {Potential net primary productivity in South America: application of a global model},
+  title        = {Potential net primary productivity in {S}outh {A}merica: application of a global model},
   author       = {J. W. Raich},
   year         = 1991,
   journal      = {Ecological Applications},
@@ -408,7 +408,7 @@
   issue        = 4
 }
 @article{swenson2012improved,
-  title        = {Improved simulation of the terrestrial hydrological cycle in permafrost regions by the Community Land Model},
+  title        = {Improved simulation of the terrestrial hydrological cycle in permafrost regions by the {C}ommunity {L}and {M}odel},
   author       = {S. C. Swenson and D. M. Lawrence and Hanna Lee},
   year         = 2012,
   month        = 9,
@@ -421,7 +421,7 @@
   issue        = 8
 }
 @article{tian1999sensitivity,
-  title        = {The sensitivity of terrestrial carbon storage to historical climate variability and atmospheric CO2 in the United States},
+  title        = {The sensitivity of terrestrial carbon storage to historical climate variability and atmospheric {CO}2 in the {U}nited {S}tates},
   author       = {H. TIAN and J. M. MELILLO and D. W. KICKLIGHTER and A. D. McGUIRE and J. HELFRICH},
   year         = 1999,
   month        = 4,
@@ -459,7 +459,7 @@
   issue        = 12
 }
 @article{yi2009interactions,
-  title        = {Interactions between soil thermal and hydrological dynamics in the response of Alaska ecosystems to fire disturbance},
+  title        = {Interactions between soil thermal and hydrological dynamics in the response of {A}laska ecosystems to fire disturbance},
   author       = {Shuhua Yi and A. David McGuire and Jennifer Harden and Eric Kasischke and Kristen Manies and Larry Hinzman and Anna Liljedahl and Jim Randerson and Heping Liu and Vladimir Romanovsky and Sergei Marchenko and Yongwon Kim},
   year         = 2009,
   month        = 6,
@@ -485,7 +485,7 @@
   issue        = 4
 }
 @article{yuan2012assessment,
-  title        = {Assessment of boreal forest historical C dynamics in the Yukon River Basin: Relative roles of warming and fire regime change},
+  title        = {Assessment of boreal forest historical {C} dynamics in the {Y}ukon {R}iver {B}asin: Relative roles of warming and fire regime change},
   author       = {F. M. Yuan and S. H. Yi and A. D. Mcguire and K. D. Johnson and J. Liang and J. W. Harden and E. S. Kasischke and W. A. Kurz},
   year         = 2012,
   month        = 12,
@@ -500,7 +500,7 @@
   pmid         = 23387112
 }
 @article{zhuang2003carbon,
-  title        = {Carbon cycling in extratropical terrestrial ecosystems of the Northern Hemisphere during the 20th century: a modeling analysis of the influences of soil thermal dynamics},
+  title        = {Carbon cycling in extratropical terrestrial ecosystems of the {N}orthern {H}emisphere during the 20th century: a modeling analysis of the influences of soil thermal dynamics},
   author       = {Q. Zhuang and A. D. McGuire and J. M. Melillo and J. S. Clein and R. J. Dargaville and D. W. Kicklighter and R. B. Myneni and J. Dong and V. E. Romanovsky and J. Harden and J. E. Hobbie},
   year         = 2003,
   month        = 1,
@@ -514,7 +514,7 @@
   issue        = 3
 }
 @article{zhuang2003modeling,
-  title        = {Modeling soil thermal and carbon dynamics of a fire chronosequence in interior Alaska},
+  title        = {Modeling soil thermal and carbon dynamics of a fire chronosequence in interior {A}laska},
   author       = {Q. Zhuang and A. D. McGuire and K. P. O'Neill and J. W. Harden and V. E. Romanovsky and J. Yarie},
   year         = 2003,
   month        = 1,


### PR DESCRIPTION
Seems like there is no clean way to automate this. This bib file was exported from Mendeley, which does not have a mechanism to properly handle the capitilization.

One alternative might be writing a custsom style in for pybibtex in conf.py.

But for now just manually add braces.