### PR TITLE
Add runmask by available params

### DIFF
--- a/scripts/util/runmask.py
+++ b/scripts/util/runmask.py
@@ -341,7 +341,7 @@ def cmdline_define():
                            the parameter folder. This will mask out any pixels 
                            whose CMT classification in the  VEG_FILE is not in 
                            the list of available CMTs from the PARAM_FOLDER.
-                           Modifies the run-mask file.'''))
+                           Creates a new run-mask file.'''))
 
   parser.add_argument("--select-only-cmt", metavar=('FOLDER','CMT'), nargs=2,
     help=textwrap.dedent('''Select only pixels with a certain CMT number. This

--- a/scripts/util/runmask.py
+++ b/scripts/util/runmask.py
@@ -9,6 +9,7 @@ import argparse
 import textwrap
 import os
 import numpy as np
+from pathlib import Path
 
 import util.input
 import util.param
@@ -462,11 +463,16 @@ def cmdline_run(args):
 
     sizey, sizex = new_mask.shape
 
-    # (Over) write the file back out
-    with nc.Dataset(mask_file + 'sample.nc', 'w') as nf:
+    # Write the mask back out to a new file.
+    #  This ensures that we retain the original mask for use
+    #  when more parameterizations are available. The user will need
+    #  to replace the mask filename in the config file.
+    mask_path = Path(mask_file)
+    new_maskfile_name = str(mask_path.parent) + '/' + mask_path.stem + '_cmtfilter.nc'
+    with nc.Dataset(new_maskfile_name, 'w') as nf:
       Y = nf.createDimension('Y', sizey)
       X = nf.createDimension('X', sizex)
-      run = nf.createVariable('run', np.int, ('Y', 'X',))
+      run = nf.createVariable('run', int, ('Y', 'X',))
       if args.verbose:
         print(f"Writing mask...{new_mask=}")
       run[:] = new_mask

--- a/scripts/util/runmask.py
+++ b/scripts/util/runmask.py
@@ -11,6 +11,7 @@ import os
 import numpy as np
 
 import util.input
+import util.param
 
 '''
 This script is for creating, modifying, and viewing run masks for dvmdostem. 
@@ -88,6 +89,67 @@ def conform_mask_timeseries(rm_m, data):
   #   print c
 
   return rm_m
+
+def conform_mask_to_available_params(param_folder, veg_file, mask_file, verbose=False):
+  """
+  Adjusts the run mask based on available CMTs in the parameter folder.
+
+  This function identifies all available Community Model Types (CMTs) in the 
+  specified parameter folder. It then modifies the run mask in the provided 
+  mask file by turning off (masking) every pixel in the vegetation file 
+  (`veg_file`) whose value is not in the list of available CMTs.
+
+  Parameters
+  ----------
+  param_folder : str
+      Path to the folder containing parameter files with available CMTs.
+  veg_file : str
+      Path to the vegetation NetCDF file containing the `veg_class` variable.
+  mask_file : str
+      Path to the run mask NetCDF file containing the `run` variable.
+  verbose : bool, optional
+      If True, prints additional information during processing. Default is False.
+
+  Returns
+  -------
+  new_mask : numpy.ndarray
+      A 2D numpy array representing the updated run mask, where pixels not 
+      matching available CMTs are turned off.
+  """
+
+  veg = nc.Dataset(os.path.join(veg_file), 'r')
+  if 'veg_class' not in veg.variables.keys():
+    raise RuntimeError(f"Invalid vegegation.nc file...missing veg_class variable {veg_file}")
+
+  mask = nc.Dataset(os.path.join(mask_file), 'r')
+  if 'run' not in mask.variables.keys():
+    raise RuntimeError(f"Invalid mask.nc file...missing run variable {mask_file}")
+
+  available_CMTs = util.param.get_available_CMTs(param_folder)
+
+  if verbose:
+    print("Available CMTs:", available_CMTs)
+    print("Initial vegetation mask:")
+    print(veg['veg_class'][:])
+
+  valid_veg = np.isin(veg['veg_class'][:], available_CMTs)
+  
+  if verbose:
+    print("Valid vegetation mask after applying available CMTs:")
+    print(valid_veg)
+
+  new_mask = np.where(valid_veg, mask['run'][:], valid_veg)
+
+  if verbose:
+    print("New run mask after applying vegetation mask:")
+    print(new_mask)
+
+  valid_veg = np.isin(veg['veg_class'][:], available_CMTs)
+  
+  new_mask = np.where(valid_veg, mask['run'][:], valid_veg)
+
+  return new_mask
+
 
 
 def conform_mask_to_inputs(in_folder, verbose=False):
@@ -271,6 +333,14 @@ def cmdline_define():
           missing data. NOTE!!: modifies run-mask.nc found in %(metavar)s, and
           ignores the files specified 'FILE' argument!'''))
 
+  parser.add_argument("--conform-mask-to-available-params", 
+      metavar=('PARAM_FOLDER', 'VEG_FILE'), nargs=2,
+      help=textwrap.dedent('''Adjust the run mask based on available CMTs in
+                           the parameter folder. This will mask out any pixels 
+                           whose CMT classification in the  VEG_FILE is not in 
+                           the list of available CMTs from the PARAM_FOLDER.
+                           Modifies the run-mask file.'''))
+
   parser.add_argument("--select-only-cmt", metavar=('FOLDER','CMT'), nargs=2,
     help=textwrap.dedent('''Select only pixels with a certain CMT number. This
           will honor any pixels that are alreay masked in the run-mask. As such, 
@@ -383,6 +453,28 @@ def cmdline_run(args):
       show_mask(os.path.join(input_folder_path, "run-mask.nc"), "New mask file showing only cmt {}".format(cmt))
     return 0
 
+  if args.conform_mask_to_available_params:
+    param_folder, veg_file = args.conform_mask_to_available_params
+
+    mask_file = args.file
+
+    new_mask = conform_mask_to_available_params(param_folder, veg_file, mask_file, verbose=args.verbose)
+
+    sizey, sizex = new_mask.shape
+
+    # (Over) write the file back out
+    with nc.Dataset(mask_file + 'sample.nc', 'w') as nf:
+      Y = nf.createDimension('Y', sizey)
+      X = nf.createDimension('X', sizex)
+      run = nf.createVariable('run', np.int, ('Y', 'X',))
+      if args.verbose:
+        print(f"Writing mask...{new_mask=}")
+      run[:] = new_mask
+
+    if args.show:
+      show_mask(mask_file, "New mask file conforming to available params")
+
+    return 0
 
   if args.conform_mask_to_inputs:
 


### PR DESCRIPTION
This adds a method to modify a run mask by
deactivating cells whose corresponding CMT
does not exist in the parameter files.

Lightly tested with a trivial case (veg(0,0) set to 60)
in the demo Toolik data, as well as with the run mask
from H01_V08, where the number of active cells was
reduced to 7985 from 8449.

This is a reduction of 464 active cells, which is the number
of cells in the vegetation file that are set to -1 (which is
neither valid nor _FillValue).