### PR TITLE
Revert "Bump tornado from 6.4.2 to 6.5.1"

### DIFF
--- a/requirements_mapping.txt
+++ b/requirements_mapping.txt
@@ -42,7 +42,7 @@ pytz==2020.4
 PyYAML==5.4
 Shapely==1.7.1
 six==1.15.0
-tornado==6.5.1
+tornado==6.4.2
 traitlets
 typing-extensions==3.7.4.3
 wcwidth==0.2.5


### PR DESCRIPTION
Reverts uaf-arctic-eco-modeling/dvm-dos-tem#783. This was an automated PR from dependabot, but it requires updating to a newer version of Python for the mapping support Docker image, which we do not want to do at this moment. 