### PR TITLE
Adding four columns to the outspec file that indicates the type of st…

### DIFF
--- a/config/output_spec.csv
+++ b/config/output_spec.csv
@@ -1,121 +1,121 @@
-Name,Description,Units,Yearly,Monthly,Daily,PFT,Compartments,Layers,Data Type,Placeholder
-ALD,Soil active layer depth,m,,invalid,invalid,invalid,invalid,invalid,double,
-AVLN,Total soil available N,g/m2,,,invalid,invalid,invalid,,double,
-BURNAIR2SOILN,Nitrogen deposit from fire emission,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNSOIL2AIRC,Burned soil C,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNSOIL2AIRN,Burned soil N,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNTHICK,Ground burn thickness,m,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2AIRC,Burned vegetation C to atmosphere,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2AIRN,Burned vegetation N to atmosphere,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2DEADC,Burned vegetation C to standing dead C,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2DEADN,Burned vegetation N to standing dead N,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2SOILABVC,Burned vegetation C to soil above,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2SOILABVN,Burned vegetation N to soil above,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2SOILBLWC,Burned vegetation C to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-BURNVEG2SOILBLWN,Burned vegetation N to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-CMTNUM,Community Type Number,m,,invalid,invalid,invalid,invalid,invalid,int,
-DEADC,Standing dead C,g/m2,,,invalid,invalid,invalid,invalid,double,
-DEADN,Standing dead N,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-DEEPC,Amorphous SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,
-DEEPDZ,Amorphous SOM horizon thickness,m,,invalid,invalid,invalid,invalid,invalid,double,
-DRIVINGNIRR,Input driving NIRR,W/m2,invalid,invalid,,invalid,invalid,invalid,float,
-DRIVINGRAINFALL,Input driving precip data after being split from snowfall,mm,,,,invalid,invalid,invalid,float,
-DRIVINGSNOWFALL,Input driving precip data after being split from rainfall,mm,,,,invalid,invalid,invalid,float,
-DRIVINGTAIR,Input driving air temperature data,degree_C,invalid,invalid,,invalid,invalid,invalid,float,
-DRIVINGVAPO,Input driving vapor pressure,hPa,invalid,invalid,,invalid,invalid,invalid,float,
-DWDC,Dead woody debris C,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-DWDN,Dead woody debris N,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-EET,Actual ET,mm/m2/time,,,,invalid,invalid,invalid,
-FRONTSDEPTH,Depth of fronts,mm,,,,invalid,invalid,,double,
-FRONTSTYPE,Front types,,,,,invalid,invalid,,int,
-GPP,GPP,g/m2/time,y,,invalid,,,invalid,double,
-GROWEND,Growing ending day,DOY,,invalid,invalid,invalid,invalid,invalid,int,
-GROWSTART,Growing starting day,DOY,,invalid,invalid,invalid,invalid,invalid,int,
-HKDEEP,Hydraulic conductivity in amorphous horizon,mm/day,,,,invalid,invalid,invalid,double,
-HKLAYER,Hydraulic conductivity by layer,mm/day,,,invalid,invalid,invalid,forced,double,
-HKMINEA,Hydraulic conductivity top mineral,mm/day,,,,invalid,invalid,invalid,double,
-HKMINEB,Hydraulic conductivity middle mineral,mm/day,,,,invalid,invalid,invalid,double,
-HKMINEC,Hydraulic conductivity bottom mineral,mm/day,,,,invalid,invalid,invalid,double,
-HKSHLW,Hydraulic conductivity in fibrous horizon,mm/day,,,,invalid,invalid,invalid,double,
-INGPP,GPP without N limitation,g/m2/time,,,invalid,,,invalid,double,
-INNPP,NPP witout N limitation,g/m2/time,,,invalid,,,invalid,double,
-INNUPTAKE,Unlimited N uptake by plants. N uptake by happy plants when N is not limited.,g/m2/time,,,invalid,,invalid,invalid,double,
-IWCLAYER,IWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,
-LAI,LAI,m2/m2,,,invalid,,invalid,invalid,double,
-LAYERDEPTH,Layer depth from the surface,m,,,invalid,invalid,invalid,forced,double,
-LAYERDZ,Thickness of layer,m,,,invalid,invalid,invalid,forced,double,
-LAYERTYPE,0:moss 1:shlw 2:deep 3:mineral,,,,invalid,invalid,invalid,forced,int,
-LFNVC,Litterfall C from non-vascular PFTs,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-LFNVN,Litterfall N from non-vascular PFTs,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-LFVC,Litterfall C from vascular PFTs,g/m2/time,,,invalid,,,invalid,double,
-LFVN,Litterfall N from vascular PFTs,g/m2/time,,,invalid,,,invalid,double,
-LWCLAYER,LWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,
-MINEC,Mineral SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,
-MOSSDEATHC,Dead moss C,g/m2,,,,invalid,invalid,invalid,double,
-MOSSDZ,Moss thickness,m,,invalid,invalid,invalid,invalid,invalid,double,
-NDRAIN,N losses from drainage (AVLN),g/m2/time,invalid,invalid,invalid,invalid,invalid,invalid,double,
-NETNMIN,Soil net N mineralization,g/m2/time,,,invalid,invalid,invalid,,double,
-NIMMOB,Nitrogen immobilization,g/m2/time,,,invalid,invalid,invalid,,double,
-NINPUT,N inputs into soil (AVLN),g/m2/time,,,invalid,invalid,invalid,invalid,double,
-NLOST,N losses from soil (AVLN),g/m2/time,,,invalid,invalid,invalid,invalid,double,
-NPP,NPP,g/m2/time,,,invalid,,,invalid,double,
-NRESORB,NRESORB,??,,,invalid,,,invalid,double,
-NUPTAKELAB,Labile N uptake by plants,g/m2/time,,,invalid,,invalid,invalid,double,
-NUPTAKEST,Structural N uptake by plants,g/m2/time,,,invalid,,,invalid,double,
-ORGN,Total soil organic N,g/m2,,,invalid,invalid,invalid,,double,
-PERCOLATION,Percolation by layer,,invalid,invalid,,invalid,invalid,forced,double,
-PERMAFROST,Permafrost (1 or 0),,,invalid,invalid,invalid,invalid,invalid,int,
-PET,Potential ET,mm/m2/time,,,,invalid,invalid,invalid,double,
-QDRAINAGE,Water drainage quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,
-QDRAINLAYER,Qdrain per layer,mm,invalid,invalid,,invalid,invalid,forced,double,
-QINFILTRATION,Water infiltration quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,
-QRUNOFF,Water runoff quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,
-RAINFALL,Total rainfall,mm,,,invalid,invalid,invalid,invalid,double,
-RECO,Summed ecosystem respiration,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-RG,Growth respiration,g/m2/time,,,invalid,,,invalid,double,
-RHDWD,Dead woody debris HR,g/m2/time,,,invalid,invalid,invalid,invalid,double,
-RHSOM,Heterotrophic respiration,g/m2/time,,,invalid,invalid,invalid,,double,
-RM,Maintenance respiration,g/m2/time,,,invalid,,,invalid,double,
-ROLB,Relative organic horizon burned ratio C,g/g,,,invalid,invalid,invalid,invalid,double,
-ROOTWATERUPTAKE,Water uptake by roots per layer,,invalid,invalid,,invalid,invalid,forced,double,
-SHLWC,Fibrous SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,
-SHLWDZ,Fibrous SOM horizon thickness,m,,invalid,invalid,invalid,invalid,invalid,double,
-SNOWEND,DOY of last snow fall,DOY,,invalid,invalid,invalid,invalid,invalid,int,
-SNOWFALL,Total snowfall,mm,,,invalid,invalid,invalid,invalid,double,
-SNOWLAYERDZ,Snow pack thickness by layer,m,,,invalid,invalid,invalid,forced,double,
-SNOWLAYERTEMP,Snow temperature by layer,degree_C,,,invalid,invalid,invalid,forced,double,
-SNOWSTART,DOY of first snow fall,DOY,,invalid,invalid,invalid,invalid,invalid,int,
-SNOWTHICK,Snow pack thickness,m,,,,invalid,invalid,invalid,double,
-SOC,Soil organic C total,g/m2,,,invalid,invalid,invalid,,double,
-SOCFROZEN,Soil organic C frozen (if yearly Dec. only),g/m2,,,invalid,invalid,invalid,invalid,double,
-SOCUNFROZEN,Soil organic C unfrozen (if yearly Dec. only),g/m2,,,invalid,invalid,invalid,invalid,double,
-SOMA,Soil organic C active,g/m2,,,invalid,invalid,invalid,,double,
-SOMCR,Soil organic C chemically resistant,g/m2,,,invalid,invalid,invalid,,double,
-SOMPR,Soil organic C physically resistant,g/m2,,,invalid,invalid,invalid,,double,
-SOMRAWC,Soil organic C raw,g/m2,,,invalid,invalid,invalid,,double,
-SWE,Snow water equivalent,kg/m2,,,,invalid,invalid,invalid,double,
-TCDEEP,Thermal conductivity in amorphous horizon,W/m/K,,,,invalid,invalid,invalid,double,
-TCLAYER,Thermal conductivity by layer,W/m/K,,,invalid,invalid,invalid,forced,double,
-TCMINEA,Thermal conductivity top mineral,W/m/K,,,,invalid,invalid,invalid,double,
-TCMINEB,Thermal conductivity middle mineral,W/m/K,,,,invalid,invalid,invalid,double,
-TCMINEC,Thermal conductivity bottom mineral,W/m/K,,,,invalid,invalid,invalid,double,
-TCSHLW,Thermal conductivity in fibrous horizon,W/m/K,,,,invalid,invalid,invalid,double,
-TDEEP,Temperature in amorphous horizon,degree_C,,,,invalid,invalid,invalid,double,
-TLAYER,Temperature by layer,degree_C,,,invalid,invalid,invalid,forced,double,
-TMINEA,Temperature top mineral,degree_C,,,,invalid,invalid,invalid,double,
-TMINEB,Temperature middle mineral,degree_C,,,,invalid,invalid,invalid,double,
-TMINEC,Temperature bottom mineral,degree_C,,,,invalid,invalid,invalid,double,
-TRANSPIRATION,Transpiration,mm/day,,,,invalid,invalid,invalid,double,
-TSHLW,Temperature in fibrous horizon,degree_C,,,,invalid,invalid,invalid,double,
-VEGC,Total veg. biomass C,g/m2,,,invalid,,,invalid,double,
-VEGNTOT,Total veg. biomass N (structural and labile),g/m2,,,invalid,invalid,invalid,invalid,double,
-VEGNLAB,Veg. biomass labile N,g/m2,,,invalid,invalid,invalid,invalid,double,
-VEGNSTR,Veg. biomass structural N,g/m2,,,invalid,,,invalid,double,
-VWCDEEP,VWC in amorphous horizon,m3/m3,,,,invalid,invalid,invalid,double,
-VWCLAYER,VWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,
-VWCMINEA,VWC top mineral,m3/m3,,,,invalid,invalid,invalid,double,
-VWCMINEB,VWC middle mineral,m3/m3,,,,invalid,invalid,invalid,double,
-VWCMINEC,VWC bottom mineral,m3/m3,,,,invalid,invalid,invalid,double,
-VWCSHLW,VWC in fibrous horizon,m3/m3,,,,invalid,invalid,invalid,double,
-WATERTAB,Water table depth below surface,m,,,,invalid,invalid,invalid,double,
-YSD,Years since last disturbance,Years,,invalid,invalid,invalid,invalid,invalid,int,
+Name,Description,Units,Yearly,Monthly,Daily,PFT,Compartments,Layers,Data Type,Placeholder,Yearsynth,Pftsynth,Compsynth,Layersynth
+ALD,Soil active layer depth,m,,invalid,invalid,invalid,invalid,invalid,double,,invalid,invalid,invalid,invalid
+AVLN,Total soil available N,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+BURNAIR2SOILN,Nitrogen deposit from fire emission,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNSOIL2AIRC,Burned soil C,g/m2/time,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+BURNSOIL2AIRN,Burned soil N,g/m2/time,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+BURNTHICK,Ground burn thickness,m,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+BURNVEG2AIRC,Burned vegetation C to atmosphere,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2AIRN,Burned vegetation N to atmosphere,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2DEADC,Burned vegetation C to standing dead C,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2DEADN,Burned vegetation N to standing dead N,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2SOILABVC,Burned vegetation C to soil above,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2SOILABVN,Burned vegetation N to soil above,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2SOILBLWC,Burned vegetation C to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+BURNVEG2SOILBLWN,Burned vegetation N to soil below,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+CMTNUM,Community Type Number,m,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+DEADC,Standing dead C,g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+DEADN,Standing dead N,g/m2/time,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+DEEPC,Amorphous SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+DEEPDZ,Amorphous SOM horizon thickness,m,,invalid,invalid,invalid,invalid,invalid,double,,invalid,invalid,invalid,invalid
+DRIVINGNIRR,Input driving NIRR,W/m2,invalid,invalid,,invalid,invalid,invalid,float,,mean,invalid,invalid,invalid
+DRIVINGRAINFALL,Input driving precip data after being split from snowfall,mm,,,,invalid,invalid,invalid,float,,sum,invalid,invalid,invalid
+DRIVINGSNOWFALL,Input driving precip data after being split from rainfall,mm,,,,invalid,invalid,invalid,float,,sum,invalid,invalid,invalid
+DRIVINGTAIR,Input driving air temperature data,degree_C,invalid,invalid,,invalid,invalid,invalid,float,,mean,invalid,invalid,invalid
+DRIVINGVAPO,Input driving vapor pressure,hPa,invalid,invalid,,invalid,invalid,invalid,float,,mean,invalid,invalid,invalid
+DWDC,Dead woody debris C,g/m2/time,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+DWDN,Dead woody debris N,g/m2/time,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+EET,Actual ET,mm/m2/time,,,,invalid,invalid,invalid,,,sum,sum,invalid,invalid
+FRONTSDEPTH,Depth of fronts,mm,,,,invalid,invalid,,double,,mean,invalid,invalid,max
+FRONTSTYPE,Front types,,,,,invalid,invalid,,int,,max,invalid,invalid,max
+GPP,GPP,g/m2/time,y,,invalid,,,invalid,double,,sum,sum,sum,invalid
+GROWEND,Growing ending day,DOY,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+GROWSTART,Growing starting day,DOY,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+HKDEEP,Hydraulic conductivity in amorphous horizon,mm/day,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+HKLAYER,Hydraulic conductivity by layer,mm/day,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,invalid
+HKMINEA,Hydraulic conductivity top mineral,mm/day,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+HKMINEB,Hydraulic conductivity middle mineral,mm/day,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+HKMINEC,Hydraulic conductivity bottom mineral,mm/day,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+HKSHLW,Hydraulic conductivity in fibrous horizon,mm/day,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+INGPP,GPP without N limitation,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+INNPP,NPP witout N limitation,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+INNUPTAKE,Unlimited N uptake by plants. N uptake by happy plants when N is not limited.,g/m2/time,,,invalid,,invalid,invalid,double,,sum,sum,invalid,invalid
+IWCLAYER,IWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,invalid
+LAI,LAI,m2/m2,,,invalid,,invalid,invalid,double,,max,sum,invalid,invalid
+LAYERDEPTH,Layer depth from the surface,m,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,invalid
+LAYERDZ,Thickness of layer,m,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,invalid
+LAYERTYPE,0:moss 1:shlw 2:deep 3:mineral,,,,invalid,invalid,invalid,forced,int,,max,invalid,invalid,invalid
+LFNVC,Litterfall C from non-vascular PFTs,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+LFNVN,Litterfall N from non-vascular PFTs,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+LFVC,Litterfall C from vascular PFTs,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+LFVN,Litterfall N from vascular PFTs,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+LWCLAYER,LWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,invalid
+MINEC,Mineral SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+MOSSDEATHC,Dead moss C,g/m2,,,,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+MOSSDZ,Moss thickness,m,,invalid,invalid,invalid,invalid,invalid,double,,invalid,invalid,invalid,invalid
+NDRAIN,N losses from drainage (AVLN),g/m2/time,invalid,invalid,invalid,invalid,invalid,invalid,double,,invalid,invalid,invalid,invalid
+NETNMIN,Soil net N mineralization,g/m2/time,,,invalid,invalid,invalid,,double,,sum,invalid,invalid,sum
+NIMMOB,Nitrogen immobilization,g/m2/time,,,invalid,invalid,invalid,,double,,sum,invalid,invalid,sum
+NINPUT,N inputs into soil (AVLN),g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+NLOST,N losses from soil (AVLN),g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+NPP,NPP,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+NRESORB,NRESORB,??,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+NUPTAKELAB,Labile N uptake by plants,g/m2/time,,,invalid,,invalid,invalid,double,,sum,sum,invalid,invalid
+NUPTAKEST,Structural N uptake by plants,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+ORGN,Total soil organic N,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+PERCOLATION,Percolation by layer,,invalid,invalid,,invalid,invalid,forced,double,,invalid,invalid,invalid,sum
+PERMAFROST,Permafrost (1 or 0),,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+PET,Potential ET,mm/m2/time,,,,invalid,invalid,invalid,double,,sum,sum,invalid,invalid
+QDRAINAGE,Water drainage quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+QDRAINLAYER,Qdrain per layer,mm,invalid,invalid,,invalid,invalid,forced,double,,invalid,invalid,invalid,sum
+QINFILTRATION,Water infiltration quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+QRUNOFF,Water runoff quotient (~ratio),,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+RAINFALL,Total rainfall,mm,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+RECO,Summed ecosystem respiration,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+RG,Growth respiration,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+RHDWD,Dead woody debris HR,g/m2/time,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+RHSOM,Heterotrophic respiration,g/m2/time,,,invalid,invalid,invalid,,double,,sum,invalid,invalid,sum
+RM,Maintenance respiration,g/m2/time,,,invalid,,,invalid,double,,sum,sum,sum,invalid
+ROLB,Relative organic horizon burned ratio C,g/g,,,invalid,invalid,invalid,invalid,double,,max,invalid,invalid,invalid
+ROOTWATERUPTAKE,Water uptake by roots per layer,,invalid,invalid,,invalid,invalid,forced,double,,sum,invalid,invalid,sum
+SHLWC,Fibrous SOM C,g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+SHLWDZ,Fibrous SOM horizon thickness,m,,invalid,invalid,invalid,invalid,invalid,double,,invalid,invalid,invalid,invalid
+SNOWEND,DOY of last snow fall,DOY,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+SNOWFALL,Total snowfall,mm,,,invalid,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+SNOWLAYERDZ,Snow pack thickness by layer,m,,,invalid,invalid,invalid,forced,double,,max,invalid,invalid,sum
+SNOWLAYERTEMP,Snow temperature by layer,degree_C,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,mean
+SNOWSTART,DOY of first snow fall,DOY,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid
+SNOWTHICK,Snow pack thickness,m,,,,invalid,invalid,invalid,double,,max,invalid,invalid,invalid
+SOC,Soil organic C total,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+SOCFROZEN,Soil organic C frozen (if yearly Dec. only),g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+SOCUNFROZEN,Soil organic C unfrozen (if yearly Dec. only),g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+SOMA,Soil organic C active,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+SOMCR,Soil organic C chemically resistant,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+SOMPR,Soil organic C physically resistant,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+SOMRAWC,Soil organic C raw,g/m2,,,invalid,invalid,invalid,,double,,mean,invalid,invalid,sum
+SWE,Snow water equivalent,kg/m2,,,,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+TCDEEP,Thermal conductivity in amorphous horizon,W/m/K,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TCLAYER,Thermal conductivity by layer,W/m/K,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,mean
+TCMINEA,Thermal conductivity top mineral,W/m/K,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TCMINEB,Thermal conductivity middle mineral,W/m/K,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TCMINEC,Thermal conductivity bottom mineral,W/m/K,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TCSHLW,Thermal conductivity in fibrous horizon,W/m/K,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TDEEP,Temperature in amorphous horizon,degree_C,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TLAYER,Temperature by layer,degree_C,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,mean
+TMINEA,Temperature top mineral,degree_C,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TMINEB,Temperature middle mineral,degree_C,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TMINEC,Temperature bottom mineral,degree_C,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+TRANSPIRATION,Transpiration,mm/day,,,,invalid,invalid,invalid,double,,sum,invalid,invalid,invalid
+TSHLW,Temperature in fibrous horizon,degree_C,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VEGC,Total veg. biomass C,g/m2,,,invalid,,,invalid,double,,mean,sum,sum,invalid
+VEGNTOT,Total veg. biomass N (structural and labile),g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VEGNLAB,Veg. biomass labile N,g/m2,,,invalid,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VEGNSTR,Veg. biomass structural N,g/m2,,,invalid,,,invalid,double,,mean,sum,sum,invalid
+VWCDEEP,VWC in amorphous horizon,m3/m3,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VWCLAYER,VWC by layer,m3/m3,,,invalid,invalid,invalid,forced,double,,mean,invalid,invalid,mean
+VWCMINEA,VWC top mineral,m3/m3,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VWCMINEB,VWC middle mineral,m3/m3,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VWCMINEC,VWC bottom mineral,m3/m3,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+VWCSHLW,VWC in fibrous horizon,m3/m3,,,,invalid,invalid,invalid,double,,mean,invalid,invalid,invalid
+WATERTAB,Water table depth below surface,m,,,,invalid,invalid,invalid,double,,max,invalid,invalid,invalid
+YSD,Years since last disturbance,Years,,invalid,invalid,invalid,invalid,invalid,int,,invalid,invalid,invalid,invalid


### PR DESCRIPTION
…ats (mean,sum,max) for output variables in case the use need to simplify the resolution before merging multiple tiles across a large region (in order to keep the merge output files relatively light weight). This information is used in the script names "merge_out_synth.py" that is stored in the repository names "Input_production".

[master 1ab30786] Adding four columns to the outspec file that indicates the type of stats (mean,sum,max) for output variables in case the use need to simplify the resolution before merging multiple tiles across a large region (in order to keep the merge output files relatively light weight). This information is used in the script names "merge_out_synth.py" that is stored in the repository names "Input_production".